### PR TITLE
Remove help/* from web_accessible_resources

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,9 +32,7 @@
     "icons/downvote.png",
     "icons/PlayerInfoIconSponsorBlocker256px.png",
     "icons/PlayerDeleteIconSponsorBlocker256px.png",
-    "popup.html",
-    "help/index.html",
-    "help/style.css"
+    "popup.html"
   ],
   "permissions": [
     "tabs",


### PR DESCRIPTION
Remove files in help/ directory from web_accessible_resources in manifest.json because the help page opens in context of the extension (no need to expose it to other contexts).