### PR TITLE
Only request published field from Invidious API

### DIFF
--- a/content.js
+++ b/content.js
@@ -376,7 +376,7 @@ function sponsorsLookup(id) {
 
             //check if this video was uploaded recently
             //use the invidious api to get the time published
-            sendRequestToCustomServer('GET', "https://invidio.us/api/v1/videos/" + id, function(xmlhttp, error) {
+            sendRequestToCustomServer('GET', "https://invidio.us/api/v1/videos/" + id + '?fields=published', function(xmlhttp, error) {
                 if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
                     let unixTimePublished = JSON.parse(xmlhttp.responseText).published;
 


### PR DESCRIPTION
The only value that appears to be used from the API response is `published`.  in which case it's possible to use `/api/v1/videos/ID?fields=published` ([docs](https://github.com/omarroth/invidious/wiki/API#fields)), which cuts down the size of the response by about 99.9% for most videos.