### PR TITLE
Some Firefox Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.js
 ignored
+.idea/

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+chrome.tabs.onUpdated.addListener(function(tabId) {
 	chrome.tabs.sendMessage(tabId, {
         message: 'update',
-	});
+	}, () => void chrome.runtime.lastError ); // Suppress error on Firefox
 });
 
 chrome.runtime.onMessage.addListener(function (request, sender, callback) {

--- a/firefox_manifest-extra.json
+++ b/firefox_manifest-extra.json
@@ -1,8 +1,0 @@
-{
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "sponsorBlocker@ajay.app",
-      "strict_min_version": "57.0"
-    }
-  }
-}

--- a/manifest.json
+++ b/manifest.json
@@ -65,5 +65,11 @@
     "128": "icons/LogoSponsorBlocker128px.png",
     "256": "icons/LogoSponsorBlocker256px.png"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "sponsorBlocker@ajay.app",
+      "strict_min_version": "57.0"
+    }
+  },
   "manifest_version": 2
 }


### PR DESCRIPTION
This stops Firefox from throwing an error every time user changes tabs if the addon is installed at all. It also moves the browser specific settings into the main manifest file which only causes Chrome to throw a warning when loading the unpacked extension and with no changes when installing the .crx.