### PR TITLE
Confirm on video that is not public [TESTING]

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -320,7 +320,7 @@
     },
     "statusReminder": {
         "message": "Check status.sponsor.ajay.app for server status."
-    }
+    },
     "confirmPrivacy": {
         "message": "Check status.sponsor.ajay.app for server status."
     }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -321,4 +321,7 @@
     "statusReminder": {
         "message": "Check status.sponsor.ajay.app for server status."
     }
+    "confirmPrivacy": {
+        "message": "Check status.sponsor.ajay.app for server status."
+    }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -322,6 +322,6 @@
         "message": "Check status.sponsor.ajay.app for server status."
     },
     "confirmPrivacy": {
-        "message": "Check status.sponsor.ajay.app for server status."
+        "message": "The video has been detected as not public. click cancel if you do not want the watch id being shared."
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -322,6 +322,6 @@
         "message": "Check status.sponsor.ajay.app for server status."
     },
     "confirmPrivacy": {
-        "message": "The video has been detected as not public. click cancel if you do not want the watch id being shared."
+        "message": "The video has been detected as not public. Click cancel if you do not want to check for sponsors."
     }
 }

--- a/content.js
+++ b/content.js
@@ -1160,7 +1160,7 @@ function getPrivacy() {
  */
 function isPublic() {
     return document.location.pathname.startsWith("/embed/") || 
-        (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
+        (["", "Learning playlist"].includes(document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText));
 }
 
 //converts time in seconds to minutes:seconds

--- a/content.js
+++ b/content.js
@@ -1159,7 +1159,7 @@ function getPrivacy() {
  * @returns {Boolean}
  */
 function isUnlisted() {
-    return document.location.pathname.startsWith("/embed/") || 
+    return !document.location.pathname.startsWith("/embed/") && 
         (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "Unlisted");
 }
 

--- a/content.js
+++ b/content.js
@@ -288,7 +288,7 @@ async function videoIDChange(id) {
     if (!id) return;
 	
     await wait(isPrivacyInfoAvailable);
-    if (!isPublic()) {
+    if (isUnlisted()) {
         let shouldContinue = confirm(chrome.i18n.getMessage("confirmPrivacy"));
         if(!shouldContinue) return;
     }
@@ -1154,13 +1154,13 @@ function getPrivacy() {
 }
 
 /**
- * Is this a public YouTube video
+ * Is this a unlisted YouTube video
  * 
  * @returns {Boolean}
  */
-function isPublic() {
+function isUnlisted() {
     return document.location.pathname.startsWith("/embed/") || 
-        (!["Private", "Unlisted"].includes(document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText));
+        (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "Unlisted");
 }
 
 //converts time in seconds to minutes:seconds

--- a/content.js
+++ b/content.js
@@ -41,17 +41,17 @@ var controls = null;
 
 // Privacy utils
 function privacy_Wait() {
-	if(document.location.pathname.startsWith("/embed/")) return true;
-	return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer").length >= 2);
+    if(document.location.pathname.startsWith("/embed/")) return true;
+    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer").length >= 2);
 }
 
 function getPrivacy() {
-	if(document.location.pathname.startsWith("/embed/")) return "Public";
+    if(document.location.pathname.startsWith("/embed/")) return "Public";
     return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
 }
 
 function isPublic() {
-	if(document.location.pathname.startsWith("/embed/")) return true;
+    if(document.location.pathname.startsWith("/embed/")) return true;
     return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
 }
 

--- a/content.js
+++ b/content.js
@@ -1160,7 +1160,7 @@ function getPrivacy() {
  */
 function isPublic() {
     return document.location.pathname.startsWith("/embed/") || 
-        (["", "Learning playlist"].includes(document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText));
+        (!["Private", "Unlisted"].includes(document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText));
 }
 
 //converts time in seconds to minutes:seconds

--- a/content.js
+++ b/content.js
@@ -41,10 +41,12 @@ var controls = null;
 
 // Privacy utils
 function getPrivacy() {
+    if(document.location.pathname.startsWith("/embed/")) return "Public";
     return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
 }
 
 function isPublic() {
+    if(document.location.pathname.startsWith("/embed/")) return true;
     return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
 }
 

--- a/content.js
+++ b/content.js
@@ -278,7 +278,10 @@ function resetValues() {
 function videoIDChange(id) {
     //if the id has not changed return
     if (sponsorVideoID === id) return;
-
+    if (!isPublic()) {
+         let shouldContinue = confirm(chrome.i18n.getMessage("confirmPrivacy"));
+	 if(!shouldContinue) return
+    }
     //set the global videoID
     sponsorVideoID = id;
 

--- a/content.js
+++ b/content.js
@@ -309,7 +309,7 @@ async function videoIDChange(id) {
         if(!shouldContinue) return;
     }
 	
-    let channelIDPromise = wait(getChannelID());
+    let channelIDPromise = wait(getChannelID);
     channelIDPromise.then(() => {
         channelIDPromise.isFulfilled = true
     }).catch(() => {

--- a/content.js
+++ b/content.js
@@ -303,16 +303,18 @@ async function videoIDChange(id) {
 	//id is not valid
     if (!id) return;
 	
-	await wait(privacy_Wait);
-	if (!isPublic()) {
-		let shouldContinue = confirm(chrome.i18n.getMessage("confirmPrivacy"));
-		if(!shouldContinue) return;
-	}
+    await wait(privacy_Wait);
+    if (!isPublic()) {
+        let shouldContinue = confirm(chrome.i18n.getMessage("confirmPrivacy"));
+        if(!shouldContinue) return;
+    }
 	
-    let channelIDPromise = wait(_ => (privacy_Wait() && getChannelID()));
+    let channelIDPromise = wait(getChannelID());
     channelIDPromise.then(() => {
-		channelIDPromise.isFulfilled = true
-	}).catch(() => channelIDPromise.isRejected  = true);
+        channelIDPromise.isFulfilled = true
+    }).catch(() => {
+        channelIDPromise.isRejected  = true
+    });
 
     //setup the preview bar
     if (previewBar == null) {

--- a/content.js
+++ b/content.js
@@ -39,22 +39,6 @@ var previewBar = null;
 //the player controls on the YouTube player
 var controls = null;
 
-// Privacy utils
-function privacy_Wait() {
-    if(document.location.pathname.startsWith("/embed/")) return true;
-    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer").length >= 2);
-}
-
-function getPrivacy() {
-    if(document.location.pathname.startsWith("/embed/")) return "Public";
-    return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
-}
-
-function isPublic() {
-    if(document.location.pathname.startsWith("/embed/")) return true;
-    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
-}
-
 // Direct Links
 videoIDChange(getYouTubeVideoID(document.URL));
 
@@ -303,7 +287,7 @@ async function videoIDChange(id) {
 	//id is not valid
     if (!id) return;
 	
-    await wait(privacy_Wait);
+    await wait(isPrivacyInfoAvailable);
     if (!isPublic()) {
         let shouldContinue = confirm(chrome.i18n.getMessage("confirmPrivacy"));
         if(!shouldContinue) return;
@@ -1157,6 +1141,27 @@ function getSponsorTimesMessage(sponsorTimes) {
     }
 
     return sponsorTimesMessage;
+}
+
+// Privacy utils
+function isPrivacyInfoAvailable() {
+    if(document.location.pathname.startsWith("/embed/")) return true;
+    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer").length >= 2);
+}
+
+function getPrivacy() {
+    if(document.location.pathname.startsWith("/embed/")) return "Public";
+    return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
+}
+
+/**
+ * Is this a public YouTube video
+ * 
+ * @returns {Boolean}
+ */
+function isPublic() {
+    return document.location.pathname.startsWith("/embed/") || 
+        (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
 }
 
 //converts time in seconds to minutes:seconds

--- a/content.js
+++ b/content.js
@@ -39,6 +39,15 @@ var previewBar = null;
 //the player controls on the YouTube player
 var controls = null;
 
+// Privacy utils
+function getPrivacy() {
+    return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
+}
+
+function isPublic() {
+    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
+}
+
 // Direct Links
 videoIDChange(getYouTubeVideoID(document.URL));
 

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,11 @@
+function getPrivacy() {
+    return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
+}
+
+function isPublic() {
+    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
+}
+
 // Function that can be used to wait for a condition before returning
 async function wait(condition, timeout = 5000, check = 100) { 
     return await new Promise((resolve, reject) => {

--- a/utils.js
+++ b/utils.js
@@ -1,11 +1,3 @@
-function getPrivacy() {
-    return document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText;
-}
-
-function isPublic() {
-    return (document.getElementsByClassName("style-scope ytd-badge-supported-renderer")[2].innerText === "");
-}
-
 // Function that can be used to wait for a condition before returning
 async function wait(condition, timeout = 5000, check = 100) { 
     return await new Promise((resolve, reject) => {


### PR DESCRIPTION
# Summary
- Added confirmPrivacy message to en
- Changed videoIDChange to async so that it can now use await
- Added Privacy utils in the content script
- return videoIDChange if user clicks cancel (Does not apply to /embed/)