### PR TITLE
Add custom server address

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -213,6 +213,15 @@
     "whatDeleteButton": {
         "message": "This is the button that allows you to clear all sponsors on the YouTube player."
     },
+    "customServerAddress": {
+        "message": "SponsorBlock Server Address"
+    },
+    "customServerAddressDescription": {
+        "message": "The address SponsorBlock uses to make calls to the server.\nIt must be formatted https://domain with no trailing forward slash (/).\nUnless you have your own server instance this should not be changed."
+    },
+    "saveCustomServerAddress": {
+        "message": "Save"
+    },
     "disableViewTracking": {
         "message": "Disable Sponsor Skip Count Tracking"
     },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -402,10 +402,16 @@
     "customServerAddressDescription": {
         "message": "The address SponsorBlock uses to make calls to the server.\nUnless you have your own server instance, this should not be changed."
     },
-    "saveCustomServerAddress": {
+    "save": {
         "message": "Save"
+    },
+    "reset": {
+        "message": "Reset"
     },
     "customAddressError": {
         "message": "This address is not in the right form. Make sure you have http:// or https:// at the begining and no slashes or sub-folders at the end."
+    },
+    "areYouSureReset": {
+        "message": "Are you sure you would like to reset this?"
     }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -213,15 +213,6 @@
     "whatDeleteButton": {
         "message": "This is the button that allows you to clear all sponsors on the YouTube player."
     },
-    "customServerAddress": {
-        "message": "SponsorBlock Server Address"
-    },
-    "customServerAddressDescription": {
-        "message": "The address SponsorBlock uses to make calls to the server.\nIt must be formatted https://domain with no trailing forward slash (/).\nUnless you have your own server instance this should not be changed."
-    },
-    "saveCustomServerAddress": {
-        "message": "Save"
-    },
     "disableViewTracking": {
         "message": "Disable Sponsor Skip Count Tracking"
     },
@@ -404,5 +395,14 @@
      },
     "shortCheck": {
         "message": "The following submission is shorter than your minimum duration option. This could mean that this is already submitted, and just being ignored due to this option. Are you sure you would like to submit?"
+    },
+    "customServerAddress": {
+        "message": "SponsorBlock Server Address"
+    },
+    "customServerAddressDescription": {
+        "message": "The address SponsorBlock uses to make calls to the server.\nIt must be formatted https://domain with no trailing forward slash (/).\nUnless you have your own server instance, this should not be changed."
+    },
+    "saveCustomServerAddress": {
+        "message": "Save"
     }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -400,9 +400,12 @@
         "message": "SponsorBlock Server Address"
     },
     "customServerAddressDescription": {
-        "message": "The address SponsorBlock uses to make calls to the server.\nIt must be formatted https://domain with no trailing forward slash (/).\nUnless you have your own server instance, this should not be changed."
+        "message": "The address SponsorBlock uses to make calls to the server.\nUnless you have your own server instance, this should not be changed."
     },
     "saveCustomServerAddress": {
         "message": "Save"
+    },
+    "customAddressError": {
+        "message": "This address is not in the right form. Make sure you have http:// or https:// at the begining and no slashes or sub-folders at the end."
     }
 }

--- a/public/options/options.css
+++ b/public/options/options.css
@@ -76,7 +76,7 @@ body {
     color: white;
 }
 
-.string-container {
+.text-label-container {
     font-size: 14px;
     color: white;
 }

--- a/public/options/options.css
+++ b/public/options/options.css
@@ -76,6 +76,11 @@ body {
     color: white;
 }
 
+.string-container {
+    font-size: 14px;
+    color: white;
+}
+
 .switch {
     position: relative;
     display: inline-block;

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -93,6 +93,25 @@
 
 			<br/>
 			<br/>
+
+			<div option-type="string-change" sync-option="customServerAddress">
+				<label class="string-container">
+					<div>__MSG_customServerAddress__</div>
+				  <input class="option-text-box" type="text">
+				</label>
+				<div class="option-button custom-server-address-button inline">
+						__MSG_saveCustomServerAddress__
+				</div>
+	
+				<br/>
+				<br/>
+	
+				<div class="small-description">__MSG_customServerAddressDescription__</div>
+			</div>
+
+			<br/>
+			<br/>
+	
 	
 			<div option-type="keybind-change" sync-option="startSponsorKeybind">
 				<div class="option-button trigger-button">

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -41,7 +41,7 @@
 			<br/>
 			<br/>
 	
-			<div option-type="text-change" sync-option="invidiousInstances">
+			<div option-type="private-text-change" sync-option="invidiousInstances">
 				<div class="option-button trigger-button">
 					__MSG_addInvidiousInstance__
 				</div>

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -248,7 +248,7 @@
 			<br/>
 			<br/>
 	
-			<div option-type="text-change" sync-option="userID" confirm-message="userIDChangeWarning">
+			<div option-type="private-text-change" sync-option="userID" confirm-message="userIDChangeWarning">
 				<div class="option-button trigger-button">
 					__MSG_changeUserID__
 				</div>
@@ -274,13 +274,15 @@
 			<br/>
 			<br/>
 
-			<div option-type="string-change" sync-option="serverAddress">
-				<label class="string-container">
+			<div option-type="text-change" sync-option="serverAddress">
+				<label class="text-label-container">
 					<div>__MSG_customServerAddress__</div>
-				  <input class="option-text-box" type="text">
+
+					<input class="option-text-box" type="text">
 				</label>
-				<div class="option-button custom-server-address-button inline">
-						__MSG_saveCustomServerAddress__
+
+				<div class="option-button text-change-set inline">
+					__MSG_saveCustomServerAddress__
 				</div>
 	
 				<br/>

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -282,7 +282,11 @@
 				</label>
 
 				<div class="option-button text-change-set inline">
-					__MSG_saveCustomServerAddress__
+					__MSG_save__
+				</div>
+
+				<div class="option-button text-change-reset inline">
+					__MSG_reset__
 				</div>
 	
 				<br/>

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -93,24 +93,6 @@
 
 			<br/>
 			<br/>
-
-			<div option-type="string-change" sync-option="serverAddress">
-				<label class="string-container">
-					<div>__MSG_customServerAddress__</div>
-				  <input class="option-text-box" type="text">
-				</label>
-				<div class="option-button custom-server-address-button inline">
-						__MSG_saveCustomServerAddress__
-				</div>
-	
-				<br/>
-				<br/>
-	
-				<div class="small-description">__MSG_customServerAddressDescription__</div>
-			</div>
-
-			<br/>
-			<br/>
 	
 	
 			<div option-type="keybind-change" sync-option="startSponsorKeybind">
@@ -164,6 +146,18 @@
 				<br/>
 
 				<div class="small-description">__MSG_minDurationDescription__</div>
+			</div>
+
+			<br/>
+			<br/>
+	
+			<div option-type="toggle" toggle-type="reverse" sync-option="dontShowNotice">
+				<label class="switch-container" label-name="__MSG_showSkipNotice__">
+					<label class="switch">
+						<input type="checkbox" checked>
+						<span class="slider round"></span>
+					</label>
+				</label>
 			</div>
 	
 			<br/>
@@ -276,19 +270,25 @@
 					</div>
 				</div>
 			</div>
-	
+
 			<br/>
 			<br/>
-	
-			<div option-type="toggle" toggle-type="reverse" sync-option="dontShowNotice">
-				<label class="switch-container" label-name="__MSG_showSkipNotice__">
-					<label class="switch">
-						<input type="checkbox" checked>
-						<span class="slider round"></span>
-					</label>
+
+			<div option-type="string-change" sync-option="serverAddress">
+				<label class="string-container">
+					<div>__MSG_customServerAddress__</div>
+				  <input class="option-text-box" type="text">
 				</label>
+				<div class="option-button custom-server-address-button inline">
+						__MSG_saveCustomServerAddress__
+				</div>
+	
+				<br/>
+				<br/>
+	
+				<div class="small-description">__MSG_customServerAddressDescription__</div>
 			</div>
-			
+	
 		</div>
 	</div>
 

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -94,7 +94,7 @@
 			<br/>
 			<br/>
 
-			<div option-type="string-change" sync-option="customServerAddress">
+			<div option-type="string-change" sync-option="serverAddress">
 				<label class="string-container">
 					<div>__MSG_customServerAddress__</div>
 				  <input class="option-text-box" type="text">

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import * as CompileConfig from "../config.json";
+
 interface SBConfig {
     userID: string,
     sponsorTimes: SBMap<string, any>,
@@ -20,7 +22,7 @@ interface SBConfig {
     invidiousUpdateInfoShowCount: number,
     autoUpvote: boolean,
     supportInvidious: false,
-    customServerAddress: string,
+    serverAddress: string,
     minDuration: number
 }
 
@@ -114,7 +116,7 @@ var Config: SBObject = {
         invidiousUpdateInfoShowCount: 0,
         autoUpvote: true,
         supportInvidious: false,
-        customServerAddress: null,
+        serverAddress: CompileConfig.serverAddress,
         minDuration: 0
     },
     localConfig: null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,8 @@ interface SBConfig {
     invidiousInstances: string[],
     invidiousUpdateInfoShowCount: number,
     autoUpvote: boolean,
-    supportInvidious: false
+    supportInvidious: false,
+    customServerAddress: string
 }
 
 interface SBObject {
@@ -111,7 +112,8 @@ var Config: SBObject = {
         invidiousInstances: ["invidio.us", "invidiou.sh", "invidious.snopyta.org"],
         invidiousUpdateInfoShowCount: 0,
         autoUpvote: true,
-        supportInvidious: false
+        supportInvidious: false,
+        customServerAddress: null 
     },
     localConfig: null,
     config: null

--- a/src/options.ts
+++ b/src/options.ts
@@ -55,28 +55,29 @@ async function init() {
                 });
                 break;
             case "text-change":
-                let button = optionsElements[i].querySelector(".trigger-button");
-                button.addEventListener("click", () => activateTextChange(<HTMLElement> optionsElements[i]));
-
                 let textChangeOption = optionsElements[i].getAttribute("sync-option");
-                // See if anything extra must be done
-                switch (textChangeOption) {
-                    case "invidiousInstances":
-                        invidiousInstanceAddInit(<HTMLElement> optionsElements[i], textChangeOption);
-                }
+                let textInput = <HTMLInputElement> optionsElements[i].querySelector(".option-text-box");
+                
+                let setButton = <HTMLElement> optionsElements[i].querySelector(".text-change-set");
 
-                break;
-            case "string-change":
-                let stringChangeOption = optionsElements[i].getAttribute("sync-option");
-                let stringInput = <HTMLInputElement> optionsElements[i].querySelector(".string-container").querySelector(".option-text-box");
-                let saveButton = <HTMLElement> optionsElements[i].querySelector(".option-button");
+                textInput.value = Config.config[textChangeOption];
 
-                stringInput.value = Config.config[stringChangeOption];
-
-                saveButton.addEventListener("click", () => {
-                   setStringConfigOption(stringInput.value, stringChangeOption);
+                setButton.addEventListener("click", () => {
+                    Config.config[textChangeOption] = textInput.value;
                 });
     
+                break;
+            case "private-text-change":
+                let button = optionsElements[i].querySelector(".trigger-button");
+                button.addEventListener("click", () => activatePrivateTextChange(<HTMLElement> optionsElements[i]));
+
+                let privateTextChangeOption = optionsElements[i].getAttribute("sync-option");
+                // See if anything extra must be done
+                switch (privateTextChangeOption) {
+                    case "invidiousInstances":
+                        invidiousInstanceAddInit(<HTMLElement> optionsElements[i], privateTextChangeOption);
+                }
+
                 break;
             case "keybind-change":
                 let keybindButton = optionsElements[i].querySelector(".trigger-button");
@@ -108,16 +109,6 @@ async function init() {
 
     optionsContainer.classList.remove("hidden");
     optionsContainer.classList.add("animated");
-}
-
-/**
- * Set the value in the string input the the defined config option
- * 
- * @param element
- * @param option
- */
-function setStringConfigOption(value: string, option: string) {
-    Config.config[option] = value;
 }
 
 /**
@@ -305,7 +296,7 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
  * 
  * @param element 
  */
-function activateTextChange(element: HTMLElement) {
+function activatePrivateTextChange(element: HTMLElement) {
     let button = element.querySelector(".trigger-button");
     if (button.classList.contains("disabled")) return;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,4 @@
 import Config from "./config";
-import * as CompileConfig from "../config.json";
 
 import Utils from "./utils";
 var utils = new Utils();
@@ -73,11 +72,6 @@ async function init() {
                 let saveButton = <HTMLElement> optionsElements[i].querySelector(".option-button");
 
                 stringInput.value = Config.config[stringChangeOption];
-                // Devs can use config.json to set server address
-                if (stringChangeOption === "customServerAddress") {
-                    stringInput.value = (Config.config.customServerAddress) ? Config.config.customServerAddress : CompileConfig.serverAddress;
-                }
-                
 
                 saveButton.addEventListener("click", () => {
                    setStringConfigOption(stringInput.value, stringChangeOption);

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,6 +63,20 @@ async function init() {
                 textInput.value = Config.config[textChangeOption];
 
                 setButton.addEventListener("click", () => {
+                    // See if anything extra must be done
+                    switch (textChangeOption) {
+                        case "serverAddress":
+                            let result = validateServerAddress(textInput.value);
+
+                            if (result !== null) {
+                                textInput.value = result;
+                            } else {
+                                return;
+                            }
+
+                            break;
+                    }
+
                     Config.config[textChangeOption] = textInput.value;
                 });
     
@@ -324,4 +338,28 @@ function activatePrivateTextChange(element: HTMLElement) {
     });
 
     element.querySelector(".option-hidden-section").classList.remove("hidden");
+}
+
+/**
+ * Validates the value used for the database server address.
+ * Returns null and alerts the user if there is an issue.
+ * 
+ * @param input Input server address
+ */
+function validateServerAddress(input: string): string {
+    // Trim the last slash if needed
+    if (input.endsWith("/")) {
+        input = input.substring(0, input.length - 1);
+    }
+
+    // Isn't HTTP protocol or has extra slashes
+    if ((!input.startsWith("https://") && !input.startsWith("http://")) 
+        || input.replace("://", "").includes("/")) {
+
+        alert(chrome.i18n.getMessage("customAddressError"));
+
+        return null;
+    }
+
+    return input;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -56,20 +56,20 @@ async function init() {
                 break;
             case "text-change":
                 let textChangeOption = optionsElements[i].getAttribute("sync-option");
-                let textInput = <HTMLInputElement> optionsElements[i].querySelector(".option-text-box");
+                let textChangeInput = <HTMLInputElement> optionsElements[i].querySelector(".option-text-box");
                 
-                let setButton = <HTMLElement> optionsElements[i].querySelector(".text-change-set");
+                let textChangeSetButton = <HTMLElement> optionsElements[i].querySelector(".text-change-set");
 
-                textInput.value = Config.config[textChangeOption];
+                textChangeInput.value = Config.config[textChangeOption];
 
-                setButton.addEventListener("click", () => {
+                textChangeSetButton.addEventListener("click", () => {
                     // See if anything extra must be done
                     switch (textChangeOption) {
                         case "serverAddress":
-                            let result = validateServerAddress(textInput.value);
+                            let result = validateServerAddress(textChangeInput.value);
 
                             if (result !== null) {
-                                textInput.value = result;
+                                textChangeInput.value = result;
                             } else {
                                 return;
                             }
@@ -77,9 +77,19 @@ async function init() {
                             break;
                     }
 
-                    Config.config[textChangeOption] = textInput.value;
+                    Config.config[textChangeOption] = textChangeInput.value;
                 });
-    
+
+                // Reset to the default if needed
+                let textChangeResetButton = <HTMLElement> optionsElements[i].querySelector(".text-change-reset");
+                textChangeResetButton.addEventListener("click", () => {
+                    if (!confirm(chrome.i18n.getMessage("areYouSureReset"))) return;
+
+                    Config.config[textChangeOption] = Config.defaults[textChangeOption];
+
+                    textChangeInput.value = Config.config[textChangeOption];
+                });
+
                 break;
             case "private-text-change":
                 let button = optionsElements[i].querySelector(".trigger-button");

--- a/src/options.ts
+++ b/src/options.ts
@@ -105,8 +105,6 @@ async function init() {
  * @param option
  */
 function setStringConfigOption(value: string, option: string) {
-    console.log(value);
-    console.log(option);
     Config.config[option] = value;
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
 import Config from "./config";
+import * as CompileConfig from "../config.json";
 
 import Utils from "./utils";
 var utils = new Utils();
@@ -66,6 +67,23 @@ async function init() {
                 }
 
                 break;
+            case "string-change":
+                let stringChangeOption = optionsElements[i].getAttribute("sync-option");
+                let stringInput = <HTMLInputElement> optionsElements[i].querySelector(".string-container").querySelector(".option-text-box");
+                let saveButton = <HTMLElement> optionsElements[i].querySelector(".option-button");
+
+                stringInput.value = Config.config[stringChangeOption];
+                // Devs can use config.json to set server address
+                if (stringChangeOption === "customServerAddress") {
+                    stringInput.value = (Config.config.customServerAddress) ? Config.config.customServerAddress : CompileConfig.serverAddress;
+                }
+                
+
+                saveButton.addEventListener("click", () => {
+                   setStringConfigOption(stringInput.value, stringChangeOption);
+                });
+    
+                break;
             case "keybind-change":
                 let keybindButton = optionsElements[i].querySelector(".trigger-button");
                 keybindButton.addEventListener("click", () => activateKeybindChange(<HTMLElement> optionsElements[i]));
@@ -78,6 +96,18 @@ async function init() {
 
     optionsContainer.classList.remove("hidden");
     optionsContainer.classList.add("animated");
+}
+
+/**
+ * Set the value in the string input the the defined config option
+ * 
+ * @param element
+ * @param option
+ */
+function setStringConfigOption(value: string, option: string) {
+    console.log(value);
+    console.log(option);
+    Config.config[option] = value;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -240,7 +240,9 @@ class Utils {
     sendRequestToServer(type: string, address: string, callback?: (xmlhttp: XMLHttpRequest, err: boolean) => any) {
         let xmlhttp = new XMLHttpRequest();
   
-        xmlhttp.open(type, CompileConfig.serverAddress + address, true);
+        let serverAddress = (Config.config.customServerAddress) ? Config.config.customServerAddress : CompileConfig.serverAddress;
+
+        xmlhttp.open(type, serverAddress + address, true);
   
         if (callback != undefined) {
             xmlhttp.onreadystatechange = function () {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import * as CompileConfig from "../config.json";
 import Config from "./config";
 
 class Utils {
@@ -240,9 +239,7 @@ class Utils {
     sendRequestToServer(type: string, address: string, callback?: (xmlhttp: XMLHttpRequest, err: boolean) => any) {
         let xmlhttp = new XMLHttpRequest();
   
-        let serverAddress = (Config.config.customServerAddress) ? Config.config.customServerAddress : CompileConfig.serverAddress;
-
-        xmlhttp.open(type, serverAddress + address, true);
+        xmlhttp.open(type, Config.config.serverAddress + address, true);
   
         if (callback != undefined) {
             xmlhttp.onreadystatechange = function () {


### PR DESCRIPTION
Let the user set a config value to use a different server without a custom build of the extention.
I maintained the ability to use the existing config.json approach to not break existing dev workflow - if you don't want this let me know and I'll change it to use the default config.