### PR TITLE
Retain decimals in seconds value when editing sponsor times

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -671,7 +671,7 @@ async function runThePopup(messageListener?: MessageListener) {
         let minutes = <HTMLInputElement> <unknown> document.getElementById(idStartName + "Minutes" + index);
         let seconds = <HTMLInputElement> <unknown> document.getElementById(idStartName + "Seconds" + index);
 
-        return parseInt(minutes.value) * 60 + parseInt(seconds.value);
+        return parseInt(minutes.value) * 60 + parseFloat(seconds.value);
     }
   
     function saveSponsorTimeEdit(index, closeEditMode = true) {


### PR DESCRIPTION
If we parse seconds as Int we loose possible decimals which makes it impossible to fine tune sponsor times when using the edit function