### PR TITLE
Restrict keybindings

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -452,5 +452,14 @@
     },
     "copyDebugInformationComplete": {
         "message": "The debug information has been copied to the clip board. Feel free to remove any information you would rather not share. Save this in a text file or paste into the bug report."
+    },
+    "theKey": {
+        "message": "The key"
+    },
+    "keyAlreadyUsedByYouTube": {
+        "message": "is already used by youtube. Please select another key."
+    },
+    "keyAlreadyUsed": {
+        "message": "is bound to another action. Please select another key."
     }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -325,7 +325,7 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
         let option = element.getAttribute("sync-option");
 
         // Don't allow keys which are already listened for by youtube 
-        let restrictedKeys = "1234567890,.jklftcbmJKLFTCBM/<> -";
+        let restrictedKeys = "1234567890,.jklftcibmJKLFTCIBMN/<> -";
         if (restrictedKeys.indexOf(key) !== -1 ) {
             element.querySelector(".option-hidden-section").classList.add("hidden");
             button.classList.remove("disabled");

--- a/src/options.ts
+++ b/src/options.ts
@@ -307,7 +307,7 @@ function activateKeybindChange(element: HTMLElement) {
 
     element.querySelector(".option-hidden-section").classList.remove("hidden");
     
-    document.addEventListener("keydown", (e) => keybindKeyPressed(element, e), {once: true});
+    document.addEventListener("keydown", (e) => keybindKeyPressed(element, e), {once: true}); 
 }
 
 /**
@@ -318,46 +318,49 @@ function activateKeybindChange(element: HTMLElement) {
  */
 function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
     var key = e.key;
+    if (["Shift", "Control", "Meta", "Alt"].indexOf(key) !== -1) {
+        document.addEventListener("keydown", (e) => keybindKeyPressed(element, e), {once: true});
+    } else {
+        let button = element.querySelector(".trigger-button");
+        let option = element.getAttribute("sync-option");
 
-    let button = element.querySelector(".trigger-button");
-    let option = element.getAttribute("sync-option");
+        // Don't allow keys which are already listened for by youtube 
+        let restrictedKeys = "1234567890,.jklftcbmJKLFTCBM/<> -";
+        if (restrictedKeys.indexOf(key) !== -1 ) {
+            element.querySelector(".option-hidden-section").classList.add("hidden");
+            button.classList.remove("disabled");
+            alert("The key " + key + " is already used by youtube. Please select another key.");
+            return;
+        }
 
-    // Don't allow keys which are already listened for by youtube 
-    let restrictedKeys = Array.from("1234567890,.jklfcbm/<> -").concat(["Shift"]);
-    if (restrictedKeys.indexOf(key) !== -1 ) {
-        element.querySelector(".option-hidden-section").classList.add("hidden");
+        // Make sure keybind isn't used by the other listener
+        // TODO: If other keybindings are going to be added, we need a better way to find the other keys used.
+        let otherKeybind = (option === "startSponsorKeybind") ? Config.config['submitKeybind'] : Config.config['startSponsorKeybind'];
+        if (key === otherKeybind) {
+            element.querySelector(".option-hidden-section").classList.add("hidden");
+            button.classList.remove("disabled");
+            alert("The key " + key + " is bound to another action. Please select another key.");
+            return;
+        }
+
+        // cancel setting a keybind
+        if (key === "Escape") {
+            element.querySelector(".option-hidden-section").classList.add("hidden");
+            button.classList.remove("disabled");
+            return;
+        }
+        
+
+        Config.config[option] = key;
+
+        let status = <HTMLElement> element.querySelector(".option-hidden-section > .keybind-status");
+        status.innerText = chrome.i18n.getMessage("keybindDescriptionComplete");
+
+        let statusKey = <HTMLElement> element.querySelector(".option-hidden-section > .keybind-status-key");
+        statusKey.innerText = key;
+
         button.classList.remove("disabled");
-        alert("The key '" + key + "' is already used by youtube. Please select another key.");
-        return;
     }
-
-    // Make sure keybind isn't used by the other listener
-    // TODO: If other keybindings are going to be added, we need a better way to find the other keys used.
-    let otherKeybind = (option === "startSponsorKeybind") ? Config.config['submitKeybind'] : Config.config['startSponsorKeybind'];
-    if (key === otherKeybind) {
-        element.querySelector(".option-hidden-section").classList.add("hidden");
-        button.classList.remove("disabled");
-        alert("The key '" + key + "' is bound to another action. Please select another key.");
-        return;
-    }
-
-    // cancel setting a keybind
-    if (key === "Escape") {
-        element.querySelector(".option-hidden-section").classList.add("hidden");
-        button.classList.remove("disabled");
-        return;
-    }
-    
-
-    Config.config[option] = key;
-
-    let status = <HTMLElement> element.querySelector(".option-hidden-section > .keybind-status");
-    status.innerText = chrome.i18n.getMessage("keybindDescriptionComplete");
-
-    let statusKey = <HTMLElement> element.querySelector(".option-hidden-section > .keybind-status-key");
-    statusKey.innerText = key;
-
-    button.classList.remove("disabled");
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -320,6 +320,26 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
     var key = e.key;
 
     let button = element.querySelector(".trigger-button");
+    let option = element.getAttribute("sync-option");
+
+    // Don't allow keys which are already listened for by youtube 
+    let restrictedKeys = Array.from("1234567890,.jklfcbm/<> -").concat(["Shift"]);
+    if (restrictedKeys.indexOf(key) !== -1 ) {
+        element.querySelector(".option-hidden-section").classList.add("hidden");
+        button.classList.remove("disabled");
+        alert("The key '" + key + "' is already used by youtube. Please select another key.");
+        return;
+    }
+
+    // Make sure keybind isn't used by the other listener
+    // TODO: If other keybindings are going to be added, we need a better way to find the other keys used.
+    let otherKeybind = (option === "startSponsorKeybind") ? Config.config['submitKeybind'] : Config.config['startSponsorKeybind'];
+    if (key === otherKeybind) {
+        element.querySelector(".option-hidden-section").classList.add("hidden");
+        button.classList.remove("disabled");
+        alert("The key '" + key + "' is bound to another action. Please select another key.");
+        return;
+    }
 
     // cancel setting a keybind
     if (key === "Escape") {
@@ -327,8 +347,7 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
         button.classList.remove("disabled");
         return;
     }
-
-    let option = element.getAttribute("sync-option");
+    
 
     Config.config[option] = key;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -344,9 +344,7 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
         if (restrictedKeys.indexOf(key) !== -1 ) {
             closeKeybindOption(element, button);
 
-            // TODO: This should be localised
-            alert("The key " + key + " is already used by youtube. Please select another key.");
-
+            alert(chrome.i18n.getMessage("theKey") + " " + key + " " + chrome.i18n.getMessage("keyAlreadyUsedByYouTube"));
             return;
         }
 
@@ -356,9 +354,7 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
         if (key === otherKeybind) {
             closeKeybindOption(element, button);
 
-            // TODO: This should be localised
-            alert("The key " + key + " is bound to another action. Please select another key.");
-
+            alert(chrome.i18n.getMessage("theKey") + " " + key + " " + chrome.i18n.getMessage("keyAlreadyUsed"));
             return;
         }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -318,14 +318,14 @@ function activateKeybindChange(element: HTMLElement) {
  */
 function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
     var key = e.key;
-    if (["Shift", "Control", "Meta", "Alt"].indexOf(key) !== -1) {
+    if (["Shift", "Control", "Meta", "Alt", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Tab"].indexOf(key) !== -1) {
         document.addEventListener("keydown", (e) => keybindKeyPressed(element, e), {once: true});
     } else {
         let button = element.querySelector(".trigger-button");
         let option = element.getAttribute("sync-option");
 
         // Don't allow keys which are already listened for by youtube 
-        let restrictedKeys = "1234567890,.jklftcibmJKLFTCIBMN/<> -";
+        let restrictedKeys = "1234567890,.jklftcibmJKLFTCIBMNP/<> -+";
         if (restrictedKeys.indexOf(key) !== -1 ) {
             element.querySelector(".option-hidden-section").classList.add("hidden");
             button.classList.remove("disabled");

--- a/src/options.ts
+++ b/src/options.ts
@@ -318,18 +318,23 @@ function activateKeybindChange(element: HTMLElement) {
  */
 function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
     var key = e.key;
+
     if (["Shift", "Control", "Meta", "Alt", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Tab"].indexOf(key) !== -1) {
+
+        // Wait for more
         document.addEventListener("keydown", (e) => keybindKeyPressed(element, e), {once: true});
     } else {
-        let button = element.querySelector(".trigger-button");
+        let button: HTMLElement = element.querySelector(".trigger-button");
         let option = element.getAttribute("sync-option");
 
         // Don't allow keys which are already listened for by youtube 
         let restrictedKeys = "1234567890,.jklftcibmJKLFTCIBMNP/<> -+";
         if (restrictedKeys.indexOf(key) !== -1 ) {
-            element.querySelector(".option-hidden-section").classList.add("hidden");
-            button.classList.remove("disabled");
+            closeKeybindOption(element, button);
+
+            // TODO: This should be localised
             alert("The key " + key + " is already used by youtube. Please select another key.");
+
             return;
         }
 
@@ -337,20 +342,21 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
         // TODO: If other keybindings are going to be added, we need a better way to find the other keys used.
         let otherKeybind = (option === "startSponsorKeybind") ? Config.config['submitKeybind'] : Config.config['startSponsorKeybind'];
         if (key === otherKeybind) {
-            element.querySelector(".option-hidden-section").classList.add("hidden");
-            button.classList.remove("disabled");
+            closeKeybindOption(element, button);
+
+            // TODO: This should be localised
             alert("The key " + key + " is bound to another action. Please select another key.");
+
             return;
         }
 
         // cancel setting a keybind
         if (key === "Escape") {
-            element.querySelector(".option-hidden-section").classList.add("hidden");
-            button.classList.remove("disabled");
+            closeKeybindOption(element, button);
+
             return;
         }
         
-
         Config.config[option] = key;
 
         let status = <HTMLElement> element.querySelector(".option-hidden-section > .keybind-status");
@@ -361,6 +367,17 @@ function keybindKeyPressed(element: HTMLElement, e: KeyboardEvent) {
 
         button.classList.remove("disabled");
     }
+}
+
+/**
+ * Closes the menu for editing the keybind
+ * 
+ * @param element 
+ * @param button 
+ */
+function closeKeybindOption(element: HTMLElement, button: HTMLElement) {
+    element.querySelector(".option-hidden-section").classList.add("hidden");
+    button.classList.remove("disabled");
 }
 
 /**


### PR DESCRIPTION
Setting certain keys as keybindings can cause it to interfere with keybindings youtube uses.

This restricts the user from setting those keys as keybindings, as well as any other keybinding the user has set SponsorBlock to listen for.

The method of alerting the user may need to be changed.

List of keys youtube uses taken from here:
https://www.hongkiat.com/blog/useful-youtube-keyboard-shortcuts-to-know/