### PR TITLE
Added hash prefix implementation (server code not yet merged) 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10494,6 +10494,11 @@
         "traverse": "0.4.x"
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-loader": "^8.0.6",
     "babel-preset-env": "^1.7.0",
     "concurrently": "^5.1.0",
+    "js-sha256": "^0.9.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -202,6 +202,12 @@
     "whatViewTracking": {
         "message": "This feature tracks which segments you have skipped to let users know how much their submission has helped others and used as a metric along with upvotes to ensure that spam doesn't get into the database. The extension sends a message to the server each time you skip a segment. Hopefully most people don't change this setting so that the view numbers are accurate. :)"
     },
+    "enableQueryByHashPrefix": {
+        "message": "Query By Hash Prefix"
+    },
+    "whatQueryByHashPrefix": {
+        "message": "Instead of requesting segments from the server using the videoID, the first 4 characters of the hash of the videoID are sent. This server will send back data for all videos with similar hashes."
+    },
     "showNotice": {
         "message": "Show Notice Again"
     },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -208,6 +208,12 @@
     "whatQueryByHashPrefix": {
         "message": "Instead of requesting segments from the server using the videoID, the first 4 characters of the hash of the videoID are sent. This server will send back data for all videos with similar hashes."
     },
+    "enableRefetchWhenNotFound": {
+        "message": "Refetch Segments On New Videos"
+    },
+    "whatRefetchWhenNotFound": {
+        "message": "If the video is new, and there are no segments found, it will keep refetching every few minutes while you watch."
+    },
     "showNotice": {
         "message": "Show Notice Again"
     },

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -321,6 +321,23 @@
 
 			<br/>
 			<br/>
+
+			<div option-type="toggle" sync-option="refetchWhenNotFound">
+				<label class="switch-container" label-name="__MSG_enableRefetchWhenNotFound__">
+					<label class="switch">
+						<input type="checkbox" checked>
+						<span class="slider round"></span>
+					</label>
+				</label>
+	
+				<br/>
+				<br/>
+	
+				<div class="small-description">__MSG_whatRefetchWhenNotFound__</div>
+			</div>
+
+			<br/>
+			<br/>
 	
 			<div option-type="toggle" sync-option="checkForUnlistedVideos">
 				<label class="switch-container" label-name="__MSG_unlistedCheck__">

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -304,6 +304,23 @@
 
 			<br/>
 			<br/>
+
+			<div option-type="toggle" sync-option="hashPrefix">
+				<label class="switch-container" label-name="__MSG_enableQueryByHashPrefix__">
+					<label class="switch">
+						<input type="checkbox" checked>
+						<span class="slider round"></span>
+					</label>
+				</label>
+	
+				<br/>
+				<br/>
+	
+				<div class="small-description">__MSG_whatQueryByHashPrefix__</div>
+			</div>
+
+			<br/>
+			<br/>
 	
 			<div option-type="toggle" sync-option="checkForUnlistedVideos">
 				<label class="switch-container" label-name="__MSG_unlistedCheck__">

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,6 @@ const utils = new Utils();
 
 interface SBConfig {
     userID: string,
-    // sponsorTimes: SBMap<string, SponsorTime[]>,
     segmentTimes: SBMap<string, SponsorTime[]>,
     defaultCategory: string,
     whitelistedChannels: string[],
@@ -35,7 +34,8 @@ interface SBConfig {
     audioNotificationOnSkip,
     checkForUnlistedVideos: boolean,
     testingServer: boolean,
-    hashPrefix: boolean
+    hashPrefix: boolean,
+    refetchWhenNotFound: boolean,
 
     // What categories should be skipped
     categorySelections: CategorySelection[],
@@ -168,6 +168,7 @@ var Config: SBObject = {
         checkForUnlistedVideos: false,
         testingServer: false,
         hashPrefix: false,
+        refetchWhenNotFound: true,
 
         categorySelections: [{
             name: "sponsor",

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ interface SBConfig {
     audioNotificationOnSkip,
     checkForUnlistedVideos: boolean,
     testingServer: boolean,
+    hashPrefix: boolean
 
     // What categories should be skipped
     categorySelections: CategorySelection[],
@@ -166,6 +167,7 @@ var Config: SBObject = {
         audioNotificationOnSkip: false,
         checkForUnlistedVideos: false,
         testingServer: false,
+        hashPrefix: false,
 
         categorySelections: [{
             name: "sponsor",

--- a/src/content.ts
+++ b/src/content.ts
@@ -633,8 +633,6 @@ function sponsorsLookup(id: string) {
     getRequest.then(async (response: FetchResponse) => {
         if (response?.ok) {
             let getResult = JSON.parse(response.responseText);
-            console.log(getResult);
-            alert(getResult.length);
             if (Config.config.hashPrefix) {
                 getResult = getResult.filter((video) => video.videoID === id);
                 if (getResult.length > 0) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -632,20 +632,23 @@ function sponsorsLookup(id: string) {
     }
     getRequest.then(async (response: FetchResponse) => {
         if (response?.ok) {
-            let getResult = JSON.parse(response.responseText);
+            let result = JSON.parse(response.responseText);
             if (Config.config.hashPrefix) {
-                getResult = getResult.filter((video) => video.videoID === id);
-                if (getResult.length > 0) {
-                    getResult = getResult[0].segments;
-                    if (getResult.length === 0) { // return if no segments found
+                result = result.filter((video) => video.videoID === id);
+                if (result.length > 0) {
+                    result = result[0].segments;
+                    if (result.length === 0) { // return if no segments found
+                        retryFetch(id);
                         return;
                     }
                 } else { // return if no video found
+                    console.log("refetching")
+                    retryFetch(id);
                     return;
                 }
             }
 
-            let recievedSegments: SponsorTime[] = getResult;
+            let recievedSegments: SponsorTime[] = result;
             if (!recievedSegments.length) {
                 console.error("[SponsorBlock] Server returned malformed response: " + JSON.stringify(recievedSegments));
                 return;
@@ -689,30 +692,36 @@ function sponsorsLookup(id: string) {
 
             sponsorLookupRetries = 0;
         } else if (response?.status === 404) {
-            sponsorDataFound = false;
-
-            //check if this video was uploaded recently
-            utils.wait(() => !!videoInfo).then(() => {
-                let dateUploaded = videoInfo?.microformat?.playerMicroformatRenderer?.uploadDate;
-
-                //if less than 3 days old
-                if (Date.now() - new Date(dateUploaded).getTime() < 259200000) {
-                    //TODO lower when server becomes better
-                    setTimeout(() => sponsorsLookup(id), 180000);
-                }
-            });
-
-            sponsorLookupRetries = 0;
+            retryFetch(id);
         } else if (sponsorLookupRetries < 90 && !recheckStarted) {
             recheckStarted = true;
 
             //TODO lower when server becomes better (back to 1 second)
             //some error occurred, try again in a second
-            setTimeout(() => sponsorsLookup(id), 10000);
+            setTimeout(() => sponsorsLookup(id), 10000 + Math.random() * 30000);
 
             sponsorLookupRetries++;
         }
     });
+}
+
+function retryFetch(id: string): void {
+    if (!Config.config.refetchWhenNotFound) return;
+
+    sponsorDataFound = false;
+
+    //check if this video was uploaded recently
+    utils.wait(() => !!videoInfo).then(() => {
+        let dateUploaded = videoInfo?.microformat?.playerMicroformatRenderer?.uploadDate;
+
+        //if less than 3 days old
+        if (Date.now() - new Date(dateUploaded).getTime() < 259200000) {
+            //TODO lower when server becomes better
+            setTimeout(() => sponsorsLookup(id), 120000);
+        }
+    });
+
+    sponsorLookupRetries = 0;
 }
 
 /**

--- a/src/content.ts
+++ b/src/content.ts
@@ -634,9 +634,7 @@ function sponsorsLookup(id: string) {
         if (response?.ok) {
             let getResult = JSON.parse(response.responseText);
             if (Config.config.hashPrefix) {
-                getResult = getResult.filter((video) => {
-                    return video.videoID = id;
-                });
+                getResult = getResult.filter((video) => video.videoID === id);
                 if (getResult.length > 0) {
                     getResult = getResult[0].segments;
                     if (getResult.length === 0) { // return if no segments found

--- a/src/content.ts
+++ b/src/content.ts
@@ -621,7 +621,7 @@ function sponsorsLookup(id: string) {
     // Check for hashPrefix setting
     let getRequest;
     if (Config.config.hashPrefix) {
-        getRequest = utils.asyncRequestToServer('GET', "/api/skipSegments/"+utils.getHash(id, 1).substr(0,4), {
+        getRequest = utils.asyncRequestToServer('GET', "/api/skipSegments/" + utils.getHash(id, 1).substr(0,4), {
             categories
         });
     } else {

--- a/src/content.ts
+++ b/src/content.ts
@@ -637,7 +637,7 @@ function sponsorsLookup(id: string) {
                 getResult = getResult.filter((video) => {
                     return video.videoID = id;
                 });
-                if (getResult.length === 1) {
+                if (getResult.length > 0) {
                     getResult = getResult[0].segments;
                     if (getResult.length === 0) { // return if no segments found
                         return;

--- a/src/content.ts
+++ b/src/content.ts
@@ -639,7 +639,7 @@ function sponsorsLookup(id: string) {
                 });
                 if (getResult.length === 1) {
                     getResult = getResult[0].segments;
-                    if (getResult.length === 0) { // return if no regments found
+                    if (getResult.length === 0) { // return if no segments found
                         return;
                     }
                 } else { // return if no video found

--- a/src/content.ts
+++ b/src/content.ts
@@ -633,6 +633,8 @@ function sponsorsLookup(id: string) {
     getRequest.then(async (response: FetchResponse) => {
         if (response?.ok) {
             let getResult = JSON.parse(response.responseText);
+            console.log(getResult);
+            alert(getResult.length);
             if (Config.config.hashPrefix) {
                 getResult = getResult.filter((video) => video.videoID === id);
                 if (getResult.length > 0) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -642,7 +642,6 @@ function sponsorsLookup(id: string) {
                         return;
                     }
                 } else { // return if no video found
-                    console.log("refetching")
                     retryFetch(id);
                     return;
                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import Config from "./config";
 import { CategorySelection, SponsorTime, FetchResponse } from "./types";
+import { sha256 } from 'js-sha256';
 
 import * as CompileConfig from "../config.json";
 
@@ -378,6 +379,20 @@ class Utils {
     isFirefox(): boolean {
         return typeof(browser) !== "undefined";
     }
+
+    getHash(value: string, times=5000): string {
+        if (times <= 0) return "";
+
+        for (let i = 0; i < times; i++) {
+            let hash = sha256.create();
+            hash.update(value);
+            hash.hex();
+            value = hash.toString();
+        }
+
+        return value;
+    }
+
 }
 
 export default Utils;


### PR DESCRIPTION
This feature changes the way segments are obtained from the server in a way that improves user privacy, but disables fetching sgements while the video is being played should they be submitted. 

Instead of requesting segments using the video ID (the string after watch?v=), the video ID is hashed and the first 4 characters of the hash are sent to the server, which returns all videos where the hash also starts with those characters. The client then selects the video it wants (if any) and uses the segments provided in that request.