### PR TITLE
fix: resolve translation template issue

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -619,5 +619,41 @@
     },
     "unsubmittedWarningDescription": {
         "message": "Zeige eine Benachrichtigung an, wenn Sie ein Video mit nicht hochgeladenen Segmenten verlassen"
+    },
+    "skip_multiple_segments": {
+        "message": "Mehrere Segmente überspringen?"
+    },
+    "skip_category_sponsor": {
+        "message": "Sponsor überspringen?"
+    },
+    "skip_category_intro": {
+        "message": "Unterbrechung/Intro Animation überspringen?"
+    },
+    "skip_category_intro_short": {
+        "message": "Unterbrechung überspringen?"
+    },
+    "skip_category_outro": {
+        "message": "Endkarten/Credits überspringen?"
+    },
+    "skip_category_interaction": {
+        "message": "Interaktions-Erinnerung (Abonnieren) überspringen?"
+    },
+    "skip_category_interaction_short": {
+        "message": "Interaktions-Erinnerung überspringen?"
+    },
+    "skip_category_selfpromo": {
+        "message": "Unbezahlt/Eigenwerbung überspringen?"
+    },
+    "skip_category_music_offtopic": {
+        "message": "Musik: Nicht-Musik-Segment überspringen?"
+    },
+    "skip_category_music_offtopic_short": {
+        "message": "Nicht-Musik überspringen?"
+    },
+    "skip_category_livestream_messages": {
+        "message": "Livestream: Spenden/Nachrichten vorlesen überspringen?"
+    },
+    "skip_category_livestream_messages_short": {
+        "message": "Nachrichten lesen überspringen?"
     }
 }

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -619,41 +619,5 @@
     },
     "unsubmittedWarningDescription": {
         "message": "Zeige eine Benachrichtigung an, wenn Sie ein Video mit nicht hochgeladenen Segmenten verlassen"
-    },
-    "skip_multiple_segments": {
-        "message": "Mehrere Segmente überspringen?"
-    },
-    "skip_category_sponsor": {
-        "message": "Sponsor überspringen?"
-    },
-    "skip_category_intro": {
-        "message": "Unterbrechung/Intro Animation überspringen?"
-    },
-    "skip_category_intro_short": {
-        "message": "Unterbrechung überspringen?"
-    },
-    "skip_category_outro": {
-        "message": "Endkarten/Credits überspringen?"
-    },
-    "skip_category_interaction": {
-        "message": "Interaktions-Erinnerung (Abonnieren) überspringen?"
-    },
-    "skip_category_interaction_short": {
-        "message": "Interaktions-Erinnerung überspringen?"
-    },
-    "skip_category_selfpromo": {
-        "message": "Unbezahlt/Eigenwerbung überspringen?"
-    },
-    "skip_category_music_offtopic": {
-        "message": "Musik: Nicht-Musik-Segment überspringen?"
-    },
-    "skip_category_music_offtopic_short": {
-        "message": "Nicht-Musik überspringen?"
-    },
-    "skip_category_livestream_messages": {
-        "message": "Livestream: Spenden/Nachrichten vorlesen überspringen?"
-    },
-    "skip_category_livestream_messages_short": {
-        "message": "Nachrichten lesen überspringen?"
     }
 }

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -271,6 +271,9 @@
     "skip": {
         "message": "Überspringen"
     },
+    "skip_category": {
+        "message": "{0} überspringen?"
+    },
     "skipped": {
         "message": "Übersprungen"
     },

--- a/public/_locales/el/messages.json
+++ b/public/_locales/el/messages.json
@@ -67,6 +67,9 @@
     "skip": {
         "message": "Παράκαμψη"
     },
+    "skip_category": {
+        "message": "Παράκαμψη {0}?"
+    },
     "skipped": {
         "message": "Παραλείφθηκε"
     },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -271,6 +271,9 @@
     "skip": {
         "message": "Skip"
     },
+    "skip_category": {
+        "message": "Skip {0}?"
+    },
     "skipped": {
         "message": "Skipped"
     },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -631,41 +631,5 @@
     },
     "unsubmittedWarningDescription": {
         "message": "Send a notification when you leave a video with segments that are not uploaded"
-    },
-    "skip_multiple_segments": {
-        "message": "Skip Multiple Segments?"
-    },
-    "skip_category_sponsor": {
-        "message": "Skip Sponsor?"
-    },
-    "skip_category_intro": {
-        "message": "Skip Intermission/Intro Animation?"
-    },
-    "skip_category_intro_short": {
-        "message": "Skip Intermission?"
-    },
-    "skip_category_outro": {
-        "message": "Skip Endcards/Credits?"
-    },
-    "skip_category_interaction": {
-        "message": "Skip Interaction Reminder (Subscribe)?"
-    },
-    "skip_category_interaction_short": {
-        "message": "Skip Interaction Reminder?"
-    },
-    "skip_category_selfpromo": {
-        "message": "Skip Unpaid/Self Promotion?"
-    },
-    "skip_category_music_offtopic": {
-        "message": "Skip Music: Non-Music Section?"
-    },
-    "skip_category_music_offtopic_short": {
-        "message": "Skip Non-Music?"
-    },
-    "skip_category_livestream_messages": {
-        "message": "Skip Livestream: Donation/Message Readings?"
-    },
-    "skip_category_livestream_messages_short": {
-        "message": "Skip Message Reading?"
     }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -631,5 +631,41 @@
     },
     "unsubmittedWarningDescription": {
         "message": "Send a notification when you leave a video with segments that are not uploaded"
+    },
+    "skip_multiple_segments": {
+        "message": "Skip Multiple Segments?"
+    },
+    "skip_category_sponsor": {
+        "message": "Skip Sponsor?"
+    },
+    "skip_category_intro": {
+        "message": "Skip Intermission/Intro Animation?"
+    },
+    "skip_category_intro_short": {
+        "message": "Skip Intermission?"
+    },
+    "skip_category_outro": {
+        "message": "Skip Endcards/Credits?"
+    },
+    "skip_category_interaction": {
+        "message": "Skip Interaction Reminder (Subscribe)?"
+    },
+    "skip_category_interaction_short": {
+        "message": "Skip Interaction Reminder?"
+    },
+    "skip_category_selfpromo": {
+        "message": "Skip Unpaid/Self Promotion?"
+    },
+    "skip_category_music_offtopic": {
+        "message": "Skip Music: Non-Music Section?"
+    },
+    "skip_category_music_offtopic_short": {
+        "message": "Skip Non-Music?"
+    },
+    "skip_category_livestream_messages": {
+        "message": "Skip Livestream: Donation/Message Readings?"
+    },
+    "skip_category_livestream_messages_short": {
+        "message": "Skip Message Reading?"
     }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Omitir"
     },
+    "skip_category": {
+        "message": "Omitir {0}?"
+    },
     "skipped": {
         "message": "Omitido"
     },

--- a/public/_locales/fi/messages.json
+++ b/public/_locales/fi/messages.json
@@ -252,6 +252,9 @@
     "skip": {
         "message": "Ohita"
     },
+    "skip_category": {
+        "message": "Ohita {0}?"
+    },
     "skipped": {
         "message": "Ohitettu"
     },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -228,6 +228,9 @@
     "skip": {
         "message": "Passer"
     },
+    "skip_category": {
+        "message": "Passer {0}?"
+    },
     "skipped": {
         "message": "Passé"
     },

--- a/public/_locales/id/messages.json
+++ b/public/_locales/id/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Lewati"
     },
+    "skip_category": {
+        "message": "Lewati {0}?"
+    },
     "skipped": {
         "message": "Dilewati"
     },

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Salta"
     },
+    "skip_category": {
+        "message": "Salta {0}?"
+    },
     "skipped": {
         "message": "Saltato"
     },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -56,6 +56,9 @@
     "skip": {
         "message": "スキップ"
     },
+    "skip_category": {
+        "message": "スキップ {0}?"
+    },
     "skipped": {
         "message": "スキップしました"
     },

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -195,6 +195,9 @@
     "skip": {
         "message": "스킵"
     },
+    "skip_category": {
+        "message": "스킵 {0}?"
+    },
     "skipped": {
         "message": "스킵됨"
     },

--- a/public/_locales/nl/messages.json
+++ b/public/_locales/nl/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Overslaan"
     },
+    "skip_category": {
+        "message": "Overslaan {0}?"
+    },
     "skipped": {
         "message": "Overgeslagen"
     },

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Pomiń"
     },
+    "skip_category": {
+        "message": "Pomiń {0}?"
+    },
     "skipped": {
         "message": "Pominięto"
     },

--- a/public/_locales/pl_PL/messages.json
+++ b/public/_locales/pl_PL/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Przewiń"
     },
+    "skip_category": {
+        "message": "Przewiń {0}?"
+    },
     "skipped": {
         "message": "Pominięto"
     },

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -200,6 +200,9 @@
     "skip": {
         "message": "Pular"
     },
+    "skip_category": {
+        "message": "Pular {0}?"
+    },
     "skipped": {
         "message": "Pulado"
     },

--- a/public/_locales/ro/messages.json
+++ b/public/_locales/ro/messages.json
@@ -246,6 +246,9 @@
     "skip": {
         "message": "Sari"
     },
+    "skip_category": {
+        "message": "Sari {0}?"
+    },
     "skipped": {
         "message": "Sărit"
     },

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Пропустить"
     },
+    "skip_category": {
+        "message": "Пропустить {0}?"
+    },
     "skipped": {
         "message": "Пропущено"
     },

--- a/public/_locales/sk/messages.json
+++ b/public/_locales/sk/messages.json
@@ -44,6 +44,9 @@
     "skip": {
         "message": "Preskočiť"
     },
+    "skip_category": {
+        "message": "Preskočiť {0}?"
+    },
     "disableAutoSkip": {
         "message": "Zakázať Automatické Preskočenie"
     },

--- a/public/_locales/sv/messages.json
+++ b/public/_locales/sv/messages.json
@@ -197,6 +197,9 @@
     "skip": {
         "message": "Hoppa över"
     },
+    "skip_category": {
+        "message": "Hoppa över {0}?"
+    },
     "skipped": {
         "message": "Skippat"
     },

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -200,6 +200,9 @@
     "skip": {
         "message": "Atla"
     },
+    "skip_category": {
+        "message": "Atla {0}?"
+    },
     "skipped": {
         "message": "Atlandı"
     },

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Пропустити"
     },
+    "skip_category": {
+        "message": "Пропустити {0}?"
+    },
     "skipped": {
         "message": "Пропущено"
     },

--- a/public/_locales/vi/messages.json
+++ b/public/_locales/vi/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "Bỏ qua"
     },
+    "skip_category": {
+        "message": "Bỏ qua {0}?"
+    },
     "skipped": {
         "message": "Đã bỏ qua"
     },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -200,6 +200,9 @@
     "skip": {
         "message": "跳过"
     },
+    "skip_category": {
+        "message": "跳过 {0}?"
+    },
     "skipped": {
         "message": "跳过"
     },

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -259,6 +259,9 @@
     "skip": {
         "message": "略過"
     },
+    "skip_category": {
+        "message": "略過 {0}?"
+    },
     "skipped": {
         "message": "已跳過"
     },

--- a/src/components/SkipNoticeComponent.tsx
+++ b/src/components/SkipNoticeComponent.tsx
@@ -78,8 +78,7 @@ class SkipNoticeComponent extends React.Component<SkipNoticeProps, SkipNoticeSta
             : "category_" + this.segments[0].category + "_short") || chrome.i18n.getMessage("category_" + this.segments[0].category);
         let noticeTitle = categoryName + " " + chrome.i18n.getMessage("skipped");
         if (!this.autoSkip) {
-            noticeTitle = chrome.i18n.getMessage(this.segments.length > 1 ? "skip_multiple_segments" 
-            : "skip_category_" + this.segments[0].category + "_short") || chrome.i18n.getMessage("skip_category_" + this.segments[0].category);
+            noticeTitle = chrome.i18n.getMessage("skip_category").replace("{0}", categoryName);
         }
     
         //add notice

--- a/src/components/SkipNoticeComponent.tsx
+++ b/src/components/SkipNoticeComponent.tsx
@@ -78,7 +78,8 @@ class SkipNoticeComponent extends React.Component<SkipNoticeProps, SkipNoticeSta
             : "category_" + this.segments[0].category + "_short") || chrome.i18n.getMessage("category_" + this.segments[0].category);
         let noticeTitle = categoryName + " " + chrome.i18n.getMessage("skipped");
         if (!this.autoSkip) {
-            noticeTitle = chrome.i18n.getMessage("skip") + " " + categoryName + "?";
+            noticeTitle = chrome.i18n.getMessage(this.segments.length > 1 ? "skip_multiple_segments" 
+            : "skip_category_" + this.segments[0].category + "_short") || chrome.i18n.getMessage("skip_category_" + this.segments[0].category);
         }
     
         //add notice


### PR DESCRIPTION
Hi there! This is my attempt to resolve #447.

### The problem (citing from #447)

> "Überspringen Unterbrechung?" should be "Unterbrechung überspringen?" but on crowdin I could only find these strings as separate parts so the grammar cannot be fixed in the translation. You would need to update the translation template to include all whole strings and not piece together the translation as it is doing now.

### Solution

I updated the default locale translation template with new strings, translated them into German and updated the skip notification popup code to use them. I hope that this is the way to go - I didn't work with crowdin yet 😬.

### Alternative solution

An alternative solution may add locale specific code [here](https://github.com/ajayyy/SponsorBlock/blob/56136d598bc1c960bc50ab09bf21ead903010370/src/components/SkipNoticeComponent.tsx#L80):

```js
if (!this.autoSkip) {
    noticeTitle = chrome.i18n.getMessage("skip") + " " + categoryName + "?";

    if(chrome.i18n.getUILanguage() == "de"){
        noticeTitle = categoryName + " " + chrome.i18n.getMessage("skip").toLowerCase() + "?";
    }
}
```