### PR TITLE
Add the official dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This will remove the need for the third party bot and add the official implementation of it.