### PR TITLE
Fix: skipping to the end of looped videos #426

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1007,7 +1007,13 @@ function skipToTime(v: HTMLVideoElement, skipTime: number[], skippingSegments: S
     let autoSkip: boolean = utils.getCategorySelection(skippingSegments[0].category)?.option === CategorySkipOption.AutoSkip;
 
     if ((autoSkip || sponsorTimesSubmitting.includes(skippingSegments[0])) && v.currentTime !== skipTime[1]) {
-        v.currentTime = skipTime[1];
+        // Fix for looped videos not working when skipping to the end #426
+        // for some reason you also can't skip to 1 second before the end
+        if (v.loop && v.duration > 1 && skipTime[1] >= v.duration - 1) {
+            v.currentTime = 0;
+        } else {
+            v.currentTime = skipTime[1];
+        }
     }
 
     if (openNotice) {


### PR DESCRIPTION
This should fix #426 

**The problem:**
If SponsorBlock skips to the end of a video in a playlist which is set to loop, the looping doesn't work, instead it goes to the next video in the playlist.

**Solution:**
Check if the time to skip to is at the end of the video, if it is and the video is set to loop, jump to the beginning.