### PR TITLE
Use formatted time inputs for segment editing

### DIFF
--- a/public/content.css
+++ b/public/content.css
@@ -372,12 +372,8 @@ input::-webkit-inner-spin-button {
 	-moz-appearance: textfield;
 }
 
-.sponsorTimeEditMinutes {
-	width: 30px;
-}
-
-.sponsorTimeEditSeconds {
-	width: 60px;
+.sponsorTimeEditInput {
+	width: 90px;
 }
 
 .sponsorNowButton {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,7 +349,7 @@ class Utils {
     }
 
     getFormattedTimeToSeconds(formatted: string): number | null {
-        const fragments = /^(?:(?:(\d+):)?(\d+):)?(\d*(?:\.\d+)?)$/.exec(formatted);
+        const fragments = /^(?:(?:(\d+):)?(\d+):)?(\d*(?:[.,]\d+)?)$/.exec(formatted);
 
         if (fragments === null) {
             return null;
@@ -357,7 +357,7 @@ class Utils {
 
         const hours = fragments[1] ? parseInt(fragments[1]) : 0;
         const minutes = fragments[2] ? parseInt(fragments[2] || '0') : 0;
-        const seconds = fragments[3] ? parseFloat(fragments[3]) : 0;
+        const seconds = fragments[3] ? parseFloat(fragments[3].replace(',', '.')) : 0;
 
         return hours * 3600 + minutes * 60 + seconds;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -323,14 +323,6 @@ class Utils {
         });
     }
 
-    getFormattedMinutes(seconds: number) {
-        return Math.floor(seconds / 60);
-    }
-
-    getFormattedSeconds(seconds: number) {
-        return seconds % 60;
-    }
-
     getFormattedTime(seconds: number, precise?: boolean): string {
         let hours = Math.floor(seconds / 60 / 60);
         let minutes = Math.floor(seconds / 60) % 60;
@@ -356,12 +348,22 @@ class Utils {
         return formatted;
     }
 
-    shortCategoryName(categoryName: string): string {
-        return chrome.i18n.getMessage("category_" + categoryName + "_short") || chrome.i18n.getMessage("category_" + categoryName);
+    getFormattedTimeToSeconds(formatted: string): number | null {
+        const fragments = /^(?:(?:(\d+):)?(\d+):)?(\d*(?:\.\d+)?)$/.exec(formatted);
+
+        if (fragments === null) {
+            return null;
+        }
+
+        const hours = fragments[1] ? parseInt(fragments[1]) : 0;
+        const minutes = fragments[2] ? parseInt(fragments[2] || '0') : 0;
+        const seconds = fragments[3] ? parseFloat(fragments[3]) : 0;
+
+        return hours * 3600 + minutes * 60 + seconds;
     }
 
-    getRawSeconds(minutes: number, seconds: number): number {
-        return minutes * 60 + seconds;
+    shortCategoryName(categoryName: string): string {
+        return chrome.i18n.getMessage("category_" + categoryName + "_short") || chrome.i18n.getMessage("category_" + categoryName);
     }
 
     isContentScript(): boolean {


### PR DESCRIPTION
Changes the segment editor to use a single input field for both the minutes and seconds part of the segment boundary times.

Additionally, removes unused util functions and saves the edits on changes to allow users to preview their changes immediately on the progress bar and to allow previewing by manually clicking on the progress bar without accidentally using the old values.

If either of the fields contains an invalid input, the time change is ignored entirely.

![image](https://user-images.githubusercontent.com/4833621/98366444-4bfa1180-2034-11eb-9417-900c4351e3e6.png)

The input field is rather permissive, allowing for quick inputs:

- The already used time format is supported (`1:20:34.12` = 1h20m34s120ms)
- An empty field is interpreted as "start of the video" (0s)
- Input containing just a number is interpreted as seconds (`24` = 24s, `15.3` = 15s300ms)
- Input containing just a number followed by `:` is interpreted as minutes (`1:` = 1m)
- Values higher than expected are allowed and interpreted correctly (`1:65` = 2m05s)
- Using a comma instead of a period is allowed, which is helpful for locales that use it as the decimal separator (fixes #535)