### PR TITLE
Fix: segment at the start not skipping

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -561,6 +561,7 @@ async function sponsorsLookup(id: string) {
 
     if (!seekListenerSetUp && !Config.config.disableSkipping) {
         seekListenerSetUp = true;
+        switchingVideos = false;
 
         video.addEventListener('play', () => {
             switchingVideos = false;


### PR DESCRIPTION
**Problem**
Sometimes segments at the start of a video are not skipped. For me, it happens if I restart my Firefox, go to YouTube, and click a video which has segments at the start.

**Video**
I made a video to show the problem.
https://youtu.be/xwyLslTYSmw
In the first half you can clearly see, that the segment doesn't skip, because I just restarted Firefox. After that, I restart Firefox again and load my modified version, which fixes this.

**Reason**
In `sponsorsLookup(id)`, the `video` variable may be `null` (maybe because of slow internet/slow hardware). This results in a retry-loop with 100ms delay. The video likely already started playing now, but the event listener for the `play` event of the video is not yet added. Because of that, `switchingVideos` is never set to `false`, and because of that, `startSkipScheduleCheckingForStartSponsors()` will be called but will instantly return and thus not skip the ad.
If you look closely at the video I made, you can see, that the video I watch is already playing when the segments appear in the timeline, so the `play` event is never called.

**Solution**
When the `video` variable is finally set and we add the event listeners, just set `switchingVideos` to `false`, so `startSkipScheduleCheckingForStartSponsors()` can do its job properly and skip the ad.