### PR TITLE
Fix German pronouns and typo

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -348,7 +348,7 @@
         "message": "Invidious-Kompatibilität"
     },
     "supportInvidiousDescription": {
-        "message": "Invidious (invidio.us) ist ein Drittanbieter-YouTube-Client. Um Support zu aktivieren, müssen Sie die zusätzlichen Berechtigungen akzeptieren. Dies funktioniert NICHT im Incongnito-modus auf Chrome und anderen Chromium-Varianten."
+        "message": "Invidious (invidio.us) ist ein Drittanbieter-YouTube-Client. Um Support zu aktivieren, musst du die zusätzlichen Berechtigungen akzeptieren. Dies funktioniert NICHT im Inkognitomodus auf Chrome und anderen Chromium-Varianten."
     },
     "optionsInfo": {
         "message": "Zu überspringende Kategorien auswählen, automatisches Überspringen, Tasten ein- & ausblenden und noch viel mehr."


### PR DESCRIPTION
This PR fixes two problems in the German translation of the `supportInvidiousDescription` string.

The rest of the file uses non-honorific pronouns, so this line should also use them (i.e. "du" instead of "Sie"). See also [my comment in PR #632](https://github.com/ajayyy/SponsorBlock/pull/632#pullrequestreview-582290744).

Plus: There is a typo in the word "Incongnito" (an extra "N"), and it is linked to the word "Modus" which should be uppercase when linked with a hyphen. But even if none of those typos were there it would *still* be incorrect, because Chrome uses the spelling "Inkognitomodus" (which is what I changed it to in this PR).