### PR TITLE
Fixed getFormattedTime sometimes returning (NaN:NaN)

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1649,5 +1649,5 @@ function showTimeWithoutSkips(skippedDuration: number): void {
     
     const durationAfterSkips = utils.getFormattedTime(video.duration - skippedDuration)
 
-    duration.innerText = (durationAfterSkips == null || skippedDuration <= 0) ? "" : " (" + durationAfterSkips + ")");
+    duration.innerText = (durationAfterSkips == null || skippedDuration <= 0) ? "" : " (" + durationAfterSkips + ")";
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1649,5 +1649,5 @@ function showTimeWithoutSkips(skippedDuration: number): void {
     
     const durationAfterSkips = utils.getFormattedTime(video.duration - skippedDuration)
 
-    duration.innerText = durationAfterSkips === "" ?  (skippedDuration <= 0 ? "" : " (" + durationAfterSkips + ")") : "";
+    duration.innerText = (durationAfterSkips == null || skippedDuration <= 0) ? "" : " (" + durationAfterSkips + ")");
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1646,6 +1646,8 @@ function showTimeWithoutSkips(skippedDuration: number): void {
 
         display.appendChild(duration);
     }
+    
+    const durationAfterSkips = utils.getFormattedTime(video.duration - skippedDuration)
 
-    duration.innerText = skippedDuration <= 0 ? "" : " (" + utils.getFormattedTime(video.duration - skippedDuration) + ")";
+    duration.innerText = durationAfterSkips === "" ?  (skippedDuration <= 0 ? "" : " (" + durationAfterSkips + ")") : "";
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -360,13 +360,13 @@ class Utils {
     getFormattedTime(seconds: number, precise?: boolean): string {
         const hours = Math.floor(seconds / 60 / 60);
         const minutes = Math.floor(seconds / 60) % 60;
-        let minutesDisplay = String(minutes);
+        let minutesDisplay = !isNaN(minutes) ? String(minutes) : '0';
         let secondsNum = seconds % 60;
         if (!precise) {
             secondsNum = Math.floor(secondsNum);
         }
 
-        let secondsDisplay = String(precise ? secondsNum.toFixed(3) : secondsNum);
+        let secondsDisplay = !isNaN(secondsNum) ? (String(precise ? secondsNum.toFixed(3) : secondsNum)) : '00';
         
         if (secondsNum < 10) {
             //add a zero

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -357,7 +357,7 @@ class Utils {
         });
     }
 
-    getFormattedTime(seconds: number, precise?: boolean): string {
+    getFormattedTime(seconds: number, precise?: boolean): string | null {
         const hours = Math.floor(seconds / 60 / 60);
         const minutes = Math.floor(seconds / 60) % 60;
         let minutesDisplay = String(minutes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -357,7 +357,7 @@ class Utils {
         });
     }
 
-    getFormattedTime(seconds: number, precise?: boolean): string | null {
+    getFormattedTime(seconds: number, precise?: boolean): string {
         const hours = Math.floor(seconds / 60 / 60);
         const minutes = Math.floor(seconds / 60) % 60;
         let minutesDisplay = String(minutes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,7 +377,7 @@ class Utils {
             minutesDisplay = "0" + minutesDisplay;
         }
         if (isNaN(hours) || isNaN(minutes)) {
-            return ""
+            return null;
         }
 
         const formatted = (hours ? hours + ":" : "") + minutesDisplay + ":" + secondsDisplay;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -360,13 +360,13 @@ class Utils {
     getFormattedTime(seconds: number, precise?: boolean): string {
         const hours = Math.floor(seconds / 60 / 60);
         const minutes = Math.floor(seconds / 60) % 60;
-        let minutesDisplay = !isNaN(minutes) ? String(minutes) : '0';
+        let minutesDisplay = String(minutes);
         let secondsNum = seconds % 60;
         if (!precise) {
             secondsNum = Math.floor(secondsNum);
         }
 
-        let secondsDisplay = !isNaN(secondsNum) ? (String(precise ? secondsNum.toFixed(3) : secondsNum)) : '00';
+        let secondsDisplay = String(precise ? secondsNum.toFixed(3) : secondsNum);
         
         if (secondsNum < 10) {
             //add a zero
@@ -375,6 +375,9 @@ class Utils {
         if (hours && minutes < 10) {
             //add a zero
             minutesDisplay = "0" + minutesDisplay;
+        }
+        if (isNaN(hours) || isNaN(minutes)) {
+            return ""
         }
 
         const formatted = (hours ? hours + ":" : "") + minutesDisplay + ":" + secondsDisplay;


### PR DESCRIPTION
getFormattedTime() with nothing passed into it and a couple other edge cases returns (NaN:NaN). This is a problem since on a slow machine getFormattedTime gets called without anything passed into it around the same time the computer is fetching the sponsor data. I haven't found the exact time/cause/scenario that it is causing it to return  this, but this function at some point returns (NaN:NaN), and this will definitely fix it. I've have a slow machine so it's really been bugging me seeing (NaN:NaN) in the video bar for a couple seconds before the page fully loads. Hopefully this should fix it.

P.S. If you want some other case during the loading (e.g. nothing instead of "0:00") that would work as well.