### PR TITLE
Fix options button icon in firefox

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -305,6 +305,11 @@ label>p, #disableExtension>p, #usernameValue, #usernameElement > div > p,#sponso
   transform: rotate(45deg);
 }
 
+.SBWhitelistIconContainer, button#optionsButton {
+  display: flex;
+  align-items: center;
+}
+
 .SBWhitelistIconContainer, button#optionsButton>img, .logoText>img, #usernameValue {
   margin-right: 8px;
 }


### PR DESCRIPTION
The options icon before was not vertically centered. This only appeared in firefox.
![comparison](https://user-images.githubusercontent.com/36422478/108693311-5b7b6880-7506-11eb-9e15-4622e4218b4a.png)


