### PR TITLE
Fix the videoRoot to also work on invidious embeds

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1529,7 +1529,7 @@ function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
 
 function addHotkeyListener(): boolean {
     let videoRoot = document.getElementById("movie_player") as HTMLDivElement;
-    if (onInvidious) videoRoot = document.getElementById("player-container") as HTMLDivElement;
+    if (onInvidious) videoRoot = (document.getElementById("player-container") ?? document.getElementById("player")) as HTMLDivElement;
 
     if (!videoRootsWithEventListeners.includes(videoRoot)) {
         videoRoot.addEventListener("keydown", hotkeyListener);


### PR DESCRIPTION
The root div of the player is not `#player-container` in invidious embeds but just `#player`. The `addHotkeyListener` function failing seems to be the root cause of all sponsor blocking failing on invidious embeds.

Fixes #645 