### PR TITLE
Partially fix YouTube TV support

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1530,6 +1530,7 @@ function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
 function addHotkeyListener(): boolean {
     let videoRoot = document.getElementById("movie_player") as HTMLDivElement;
     if (onInvidious) videoRoot = (document.getElementById("player-container") ?? document.getElementById("player")) as HTMLDivElement;
+    if (video.baseURI.startsWith("https://www.youtube.com/tv#/")) videoRoot = document.querySelector("ytlr-watch-page") as HTMLDivElement;
 
     if (!videoRootsWithEventListeners.includes(videoRoot)) {
         videoRoot.addEventListener("keydown", hotkeyListener);

--- a/src/content.ts
+++ b/src/content.ts
@@ -1532,7 +1532,7 @@ function addHotkeyListener(): boolean {
     if (onInvidious) videoRoot = (document.getElementById("player-container") ?? document.getElementById("player")) as HTMLDivElement;
     if (video.baseURI.startsWith("https://www.youtube.com/tv#/")) videoRoot = document.querySelector("ytlr-watch-page") as HTMLDivElement;
 
-    if (!videoRootsWithEventListeners.includes(videoRoot)) {
+    if (videoRoot && !videoRootsWithEventListeners.includes(videoRoot)) {
         videoRoot.addEventListener("keydown", hotkeyListener);
         videoRootsWithEventListeners.push(videoRoot);
         return true;


### PR DESCRIPTION
This partially resolves issue #213 by using a different selector in addHotkeyListener() when viewing YouTube's TV interface at youtube.com/tv. Before this fix addHotkeyListener() would return an exception and lead SponsorBlock to assume that there are no segments in the video.

I couldn't get the SponsorBlock buttons and progress bar to work unfortunately, as YouTube TV's interface is completely different from standard YouTube.