### PR TITLE
Skip count sending and counting on manual skip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ web-ext-artifacts
 .vscode/
 dist/
 tmp/
+.DS_Store

--- a/public/help/index_en.html
+++ b/public/help/index_en.html
@@ -47,7 +47,7 @@
       <br/>
       <br/>
 
-      Whenever you skip a segment, you will get notification. If the timing seems wrong vote down by clicking down vote! You can also vote in the popup.
+      Whenever you skip a segment, you will get notice. If the timing seems wrong vote down by clicking downvote! You can also vote in the popup.
     </p>
 
     <div class="center"><img height="120px" src="https://user-images.githubusercontent.com/12688112/63067735-5a638700-bede-11e9-8147-f321b57527ec.gif"></div>

--- a/public/help/index_en.html
+++ b/public/help/index_en.html
@@ -42,12 +42,12 @@
           <img src="https://i.imgur.com/caf5Bju.png">
       </span>
 
-      Videos will automatically be skipped if they are found in the database. You can open the popup by clicking the extension icon to get a preview of what they are.
+      Video segments will automatically be skipped if they are found in the database. You can open the popup by clicking the extension icon to get a preview of what they are.
       
       <br/>
       <br/>
 
-      Whenever you skip a video, you will get a notice report that submission. If the timing seems wrong, report it! You can also vote in the popup. The extension auto upvotes it if you don't report it, so make sure to report when necessary (this can be disabled in the options).
+      Whenever you skip a segment, you will get notification. If the timing seems wrong vote down by clicking down vote! You can also vote in the popup.
     </p>
 
     <div class="center"><img height="120px" src="https://user-images.githubusercontent.com/12688112/63067735-5a638700-bede-11e9-8147-f321b57527ec.gif"></div>
@@ -81,8 +81,8 @@
     <h1>This is too slow</h1>
 
     <p>
-      There are hotkeys if you want to use them. You must be focused on the YouTube player to use them. Press the semicolon key to indicate the start/end of a sponsor segment and click the appostrophe to submit.
-      These can be changed in the options. If you don't use QWERTY, you should probably change the keybinds.
+      There are hotkeys if you want to use them. You must be focused on the YouTube player to use them. Press the semicolon key to indicate the start/end of a sponsor segment and click the apostrophe to submit.
+      These can be changed in the options. If you don't use QWERTY, you should probably change the keybinding.
     </p>
 
     <h1>I hate these buttons, they are so ugly</h1>

--- a/src/content.ts
+++ b/src/content.ts
@@ -989,7 +989,7 @@ function previewTime(time: number, unpause = true) {
 function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: number, fullSkip: boolean) {
     if (!Config.config.trackViewCount) return;
     
-    let counted = false
+    let counted = false;
     for (const segment of skippingSegments) {
         const index = sponsorTimes.indexOf(segment);
         if (index !== -1 && !sponsorSkipped[index]) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1028,7 +1028,7 @@ function skipToTime(v: HTMLVideoElement, skipTime: number[], skippingSegments: S
     }
 
     //send telemetry that a this sponsor was skipped
-    if (autoSkip) sendTelemetryAndCount(skippingSegments, skipTime[1] - skipTime[0], true)
+    if (autoSkip) sendTelemetryAndCount(skippingSegments, skipTime[1] - skipTime[0], true);
 }
 
 function unskipSponsorTime(segment: SponsorTime) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -982,6 +982,23 @@ function previewTime(time: number, unpause = true) {
     }
 }
 
+//send telemetry and count skip
+function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: number, fullSkip: boolean) {
+    let counted = false
+    for (const segment of skippingSegments) {
+        const index = sponsorTimes.indexOf(segment);
+        if (index !== -1 && !sponsorSkipped[index]) {
+            if (!counted) {
+                Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
+                Config.config.skipCount = Config.config.skipCount + 1;
+                counted = true
+            }
+            if (fullSkip) utils.asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
+            sponsorSkipped[index] = true;
+        }
+    }
+}
+
 //skip from the start time to the end time for a certain index sponsor time
 function skipToTime(v: HTMLVideoElement, skipTime: number[], skippingSegments: SponsorTime[], openNotice: boolean) {
     // There will only be one submission if it is manual skip
@@ -1005,29 +1022,7 @@ function skipToTime(v: HTMLVideoElement, skipTime: number[], skippingSegments: S
     }
 
     //send telemetry that a this sponsor was skipped
-    if (Config.config.trackViewCount && autoSkip) {
-        let alreadySkipped = false;
-        let isPreviewSegment = false;
-
-        for (const segment of skippingSegments) {
-            const index = sponsorTimes.indexOf(segment);
-            if (index !== -1 && !sponsorSkipped[index]) {
-                utils.asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
-
-                sponsorSkipped[index] = true;
-            } else if (sponsorSkipped[index]) {
-                alreadySkipped = true;
-            }
-
-            if (index === -1) isPreviewSegment = true;
-        }
-        
-        // Count this as a skip
-        if (!alreadySkipped && !isPreviewSegment) {
-            Config.config.minutesSaved = Config.config.minutesSaved + (skipTime[1] - skipTime[0]) / 60;
-            Config.config.skipCount = Config.config.skipCount + 1;
-        }
-    }
+    if (Config.config.trackViewCount && autoSkip) sendTelemetryAndCount(skippingSegments, skipTime[1] - skipTime[0], true)
 }
 
 function unskipSponsorTime(segment: SponsorTime) {
@@ -1037,9 +1032,15 @@ function unskipSponsorTime(segment: SponsorTime) {
     }
 }
 
-function reskipSponsorTime(segment: SponsorTime) {
-    video.currentTime = segment.segment[1];
+// value determining when to count segment as skipped and send telemetry to server (percent based)
+let manualSkipPercentCount = 0.5;
 
+function reskipSponsorTime(segment: SponsorTime) {
+    let skippedTime = segment.segment[1] - video.currentTime;
+    let segmentDuration = segment.segment[1] - segment.segment[0];
+    let fullSkip = skippedTime / segmentDuration > manualSkipPercentCount ? true : false
+    video.currentTime = segment.segment[1];
+    sendTelemetryAndCount([segment], skippedTime, fullSkip)
     startSponsorSchedule(true, segment.segment[1], false);
 }
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -991,15 +991,14 @@ function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: 
     for (const segment of skippingSegments) {
         const index = sponsorTimes.indexOf(segment);
         if (index !== -1 && !sponsorSkipped[index]) {
-            if (Config.config.trackViewCount) {
-                if (!counted) {
-                    Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
-                    Config.config.skipCount = Config.config.skipCount + 1;
-                    counted = true
-                }
-                if (fullSkip) utils.asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
-            }
             sponsorSkipped[index] = true;
+            if (!Config.config.trackViewCount) return
+            if (!counted) {
+                Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
+                Config.config.skipCount = Config.config.skipCount + 1;
+                counted = true
+            }
+            if (fullSkip) utils.asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
         }
     }
 }


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

Closes #743 

```typescript
// value determining when to count segment as skipped and send telemetry to server (percent based)
let manualSkipPercentCount = 0.5;
```
This variable controls when manual skip is considered "fullSkip". If it is considered full skip telemetry will be sent to the server. If not it will be only counted locally. Also, when segment was skipped is current "watch session"(resets after window reload) skip will not count and telemetry will not send.

 Added here commit with help updates that closes #732 