### PR TITLE
Change to "start/stop segment keybind"

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -239,7 +239,7 @@
         "message": "Set key for skipping a segment"
     },
     "setStartSponsorShortcut": {
-        "message": "Set key for start segment keybind"
+        "message": "Set key for start/stop segment keybind"
     },
     "setSubmitKeybind": {
         "message": "Set key for submission keybind"


### PR DESCRIPTION
Change "Set key for start segment keybind" to "Set key for start/stop segment keybind", since it is more accurate to the actual feature!

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0
