### PR TITLE
edit old link to 3rd-party-ports in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The backend server code is available here: https://github.com/ajayyy/SponsorBloc
 
 To make sure that this project doesn't die, I have made the database publicly downloadable at https://sponsor.ajay.app/database ([License](https://github.com/ajayyy/SponsorBlock/wiki/Database-and-API-License)). If you are planning on using the database in another project, please read the [API Docs](https://github.com/ajayyy/SponsorBlock/wiki/API-Docs) page for more information.
 
-The dataset and API are now being used in some [ports](https://github.com/ajayyy/SponsorBlock/wiki/Unofficial-Ports) as well as a [neural network](https://github.com/andrewzlee/NeuralBlock).
+The dataset and API are now being used in some [ports](https://github.com/ajayyy/SponsorBlock/wiki/3rd-Party-Ports) as well as a [neural network](https://github.com/andrewzlee/NeuralBlock).
 
 # API
 


### PR DESCRIPTION
Since the README still contained the [old link to 3rd-party-ports in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Unofficial-Ports), I edited it to be [the new one](https://github.com/ajayyy/SponsorBlock/wiki/3rd-Party-Ports)!

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0
