### PR TITLE
Fix for an "enable category" popup

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -239,7 +239,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
 
     categorySelectionChange(event: React.ChangeEvent<HTMLSelectElement>): void {
         // See if show more categories was pressed
-        if (!Config.config.categorySelections.some((category) => category.name === event.target.value)) {
+        if (event.target.value !== DEFAULT_CATEGORY && !Config.config.categorySelections.some((category) => category.name === event.target.value)) {
             const chosenCategory = event.target.value;
             event.target.value = DEFAULT_CATEGORY;
             


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

If you choose any category when editing a segment, and then choose the "Choose a category" one, it triggers the enable category message with an empty category name. This is a fix for that.
Tested, works.