### PR TITLE
Highlightbutton now persists. Implements #953

### DIFF
--- a/src/js-components/skipButtonControlBar.ts
+++ b/src/js-components/skipButtonControlBar.ts
@@ -84,7 +84,7 @@ export class SkipButtonControlBar {
 
     startTimer(): void {
         this.stopTimer();
-        this.timeout = setTimeout(() => this.disable(), Math.max(Config.config.skipNoticeDuration, this.duration) * 1000);
+        this.timeout = setTimeout(() => this.textContainer.innerText = "", Math.max(Config.config.skipNoticeDuration, this.duration) * 1000);
     }
 
     disable(): void {
@@ -94,7 +94,7 @@ export class SkipButtonControlBar {
 
     toggleSkip(): void {
         this.skip(this.segment);
-        this.disable();
+        this.stopTimer();
+        this.textContainer.innerText = "";
     }
 }
-


### PR DESCRIPTION
Previewbutton now persists for the entire Video, even after pressing it. The text inside it will disappear after the timer runs out (also refreshed when hovering over it) or when pressing the button.

This is great for when the highlight-button disappears before you could make the decision if you want to skip. Also you can easily skip to the highligh multiple times, which is pretty reasonable, because it is a highlight. The text disappearing only after a timeout makes sure that new users still know what the button does.

Tested in firefox and chrome and it works fine.

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
