### PR TITLE
Copy segments into your unsubmitted and SkipNotice changes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,14 @@ class SBMap<T, U> extends Map {
         this.update();
         return result;
     }
+
+    addArray(key: T, value: U) {
+        // Expand an array by value
+        let result = super.get(key).concat(value);
+        this.set(key, result);
+        this.update();
+        return result;
+    }
 	
     delete(key) {
         const result = super.delete(key);

--- a/src/content.ts
+++ b/src/content.ts
@@ -1682,8 +1682,11 @@ function resetSponsorSubmissionNotice() {
 }
 
 function submitSponsorTimes() {
-    if (submissionNotice !== null) return;
-
+    if (submissionNotice !== null){
+        submissionNotice.noticeElement.style.display = (submissionNotice.noticeElement.style.display === "none") ? null : "none";
+        return;
+    } 
+    
     if (sponsorTimesSubmitting !== undefined && sponsorTimesSubmitting.length > 0) {
         submissionNotice = new SubmissionNotice(skipNoticeContentContainer, sendSubmitMessage);
     }


### PR DESCRIPTION
- [ ] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

Adds a copy button to the SkipNotice, which copies the skipped segment and creates an unsubmitted one with the same category and timings. SkipNoticeUI states have been made more responsive. The SubmissionNotice opener button is now a toggle.