### PR TITLE
Added margin-bottom for #sponsorblockPopup

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -46,6 +46,7 @@
   width: 330px;
   padding: 22px;
   text-align: center;
+  margin-bottom: var(--ytd-margin-6x);
 }
 
 #issueReporterTimeButtons > .votingButtons > .segmentTimeButton {


### PR DESCRIPTION
This margin is to separate popup window from playlist/related videos list.

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
