### PR TITLE
Fix mouse wheel can enter edit mode

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -152,8 +152,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                 
                 <div id={"sponsorTimesContainer" + this.idSuffix}
                     className="sponsorTimeDisplay"
-                    onClick={this.toggleEditTime.bind(this)}
-                    onWheel={this.toggleEditTime.bind(this)}>
+                    onClick={this.toggleEditTime.bind(this)}>
                         {utils.getFormattedTime(segment[0], true) +
                             ((!isNaN(segment[1]) && getCategoryActionType(sponsorTime.category) === CategoryActionType.Skippable)
                                 ? " " + chrome.i18n.getMessage("to") + " " + utils.getFormattedTime(segment[1], true) : "")}


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

As discussed on Discord. This PR removes the ability to start edit mode from the mouse. The reasoning being:

- when there are enough segments to require a scrollbar, scrolling results in accidental time edits,
- the timestamp text doesn't correlate with the position of the corresponding input field, meaning the user might start scrolling over the end timestamp and instead start editing the start timestamp (especially important if the timestamp ends up having a pencil icon after it in an upcoming PR).

https://discord.com/channels/603643120093233162/607338052221665320/901194526973108255