### PR TITLE
Fix time adjustment with ctrl+wheel changes page zoom

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -262,7 +262,10 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
         } else {
             step = (e.ctrlKey) ? 0.1 : 0.01;
         }
-        
+
+        // Prevent the browser from changing page zoom
+        e.preventDefault();
+
         const sponsorTimeEdits = this.state.sponsorTimeEdits;
         let timeAsNumber = utils.getFormattedTimeToSeconds(this.state.sponsorTimeEdits[index]);
         if (timeAsNumber !== null && e.deltaY != 0) {


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

Prevents the page zoom from changing when adjusting the segment start/end time with a mouse wheel while holding down control.

~~How did no one catch this?~~