### PR TITLE
fix "cannot read properties of null" when voting on full video tag

### DIFF
--- a/src/utils/noticeUtils.ts
+++ b/src/utils/noticeUtils.ts
@@ -16,6 +16,6 @@ export function downvoteButtonColor(segments: SponsorTime[], actionState: SkipNo
         return (actionState === downvoteType) ? Config.config.colorPalette.red : Config.config.colorPalette.white;
     } else {
         // You dont have segment selectors so the lockbutton needs to be colored and cannot be selected.
-        return Config.config.isVip && segments[0].locked === 1 ? Config.config.colorPalette.locked : Config.config.colorPalette.white;
+        return Config.config.isVip && segments?.[0].locked === 1 ? Config.config.colorPalette.locked : Config.config.colorPalette.white;
     }
 }


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

fixes error 
```ts
Uncaught TypeError: Cannot read properties of null (reading '0')
    at Object.t.downvoteButtonColor
```