### PR TITLE
fix: ignore switchingVideos in Safari

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -879,7 +879,8 @@ function retryFetch(): void {
  * Ex. When segments are first loaded
  */
 function startSkipScheduleCheckingForStartSponsors() {
-    if (!switchingVideos && sponsorTimes) {
+	// switchingVideos is ignored in Safari due to event fire order. See #1142
+    if ((!switchingVideos || isSafari) && sponsorTimes) {
         // See if there are any starting sponsors
         let startingSegmentTime = getStartTimeFromUrl(document.URL) || -1;
         let found = false;


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

This disables the `switchingVideos` check in the `startSkipScheduleCheckingForStartSponsors` function for Safari as discussed in #1142.

Closes #1142 