### PR TITLE
Fix alt-tab, round 2

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1987,7 +1987,7 @@ function addPageListeners(): void {
 function addHotkeyListener(): void {
     document.addEventListener("keydown", hotkeyListener);
     document.addEventListener("keyup", (e) => pressedKeys.delete(e.key));
-    document.addEventListener("focus", (e) => pressedKeys.clear());
+    window.addEventListener("focus", (e) => pressedKeys.clear());
 }
 
 function hotkeyListener(e: KeyboardEvent): void {


### PR DESCRIPTION
- I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
The focus event was not firing in Chrome on document, only on window.
Fixes keyboard shortcuts messing up after alt+tab in Chrome. (from #1197)