### PR TITLE
Fix minor typos and inconsistencies

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -101,7 +101,7 @@
         "message": "It seems the server is down. Contact the dev immediately."
     },
     "connectionError": {
-        "message": "A connection error has occured. Error code: "
+        "message": "A connection error has occurred. Error code: "
     },
     "clearTimes": {
         "message": "Clear Segments"
@@ -353,7 +353,7 @@
         "message": "Show Time With Skips Removed"
     },
     "showTimeWithSkipsDescription": {
-        "message": "This time appears in brackets next to the current time on below the seekbar. This shows the total video duration minus any segments. This includes segments marked as only \"Show In Seekbar\"."
+        "message": "This time appears in brackets next to the current time on below the Seek Bar. This shows the total video duration minus any segments. This includes segments marked as only \"Show In Seek Bar\"."
     },
     "youHaveSkipped": {
         "message": "You've skipped "
@@ -407,7 +407,7 @@
         "message": "Supported Sites: "
     },
     "optionsInfo": {
-        "message": "Enable Invidious support, disable autoskip, hide buttons and more."
+        "message": "Enable Invidious support, disable auto skip, hide buttons and more."
     },
     "addInvidiousInstance": {
         "message": "Add 3rd-Party Client Instance"
@@ -496,7 +496,7 @@
     "incorrectlyFormattedOptions": {
         "message": "This JSON is not formatted correctly. Your options have not been changed."
     },
-    "confirmNoticeTitle" : {
+    "confirmNoticeTitle": {
         "message": "Submit Segment"
     },
     "submit": {


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

Fixed the following in [`public/_locales/en/messages.json`](https://github.com/ajayyy/SponsorBlock/pull/1220/commits/a64deb2e1811129d4f812d02651bde282e041735#diff-d5a5a9eb2f0d2c86006fb09bf07a55d4af6227b1dba33edb6c36a78871f1641f):

- Typo "occured" -> "occurred"
- Changed two instances of "seekbar" and "Seekbar" to the already used "Seek Bar"
- Changed one instance of "autoskip" to the already used "auto skip"