### PR TITLE
Improve popup alert and fix Firefox issues

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -29,6 +29,8 @@
 
 #sponsorBlockPopupHTML {
   color-scheme: dark;
+  max-height: 600px;
+  overflow-y: auto;
 }
 
 #sponsorBlockPopupBody {

--- a/public/popup.css
+++ b/public/popup.css
@@ -475,7 +475,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 130px;
-  margin-right: 8px;
+  margin: 0 8px 0 0;
 }
 
 /*
@@ -531,16 +531,12 @@
 }
 
 /*
- * Generic spacing classes
+ * Generic utilities
  */
 
-.u-mZ {
+ #sponsorBlockPopupBody .u-mZ {
   margin: 0 !important;
 }
-
-/*
- * Generic hide utility classes
- */
 
 #sponsorBlockPopupBody .hidden {
   display: none !important;

--- a/public/popup.css
+++ b/public/popup.css
@@ -317,7 +317,7 @@
 
 .sponsorStartHint {
   display: block;
-  margin-bottom: 12px;
+  padding: 0 10px 12px;
 }
 
 /*
@@ -379,7 +379,7 @@
 .sbYourWorkCols > div {
   display: flex;
   align-items: center;
-  width: 50%;
+  flex-basis: 50%;
   justify-content: center;
 }
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -16,6 +16,14 @@
 }
 
 /*
+ * Disable popup max height when displayed in-page
+ */
+
+#sponsorBlockPopupContainer #sponsorBlockPopupHTML {
+  max-height: none;
+}
+
+/*
  * Disable fixed popup width when displayed in-page
  */
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -34,6 +34,7 @@
 #sponsorBlockPopupBody {
   margin: 0;
   width: 374px;
+  max-width: 100%; /* NOTE: Ensures content doesn't exceed restricted popup widths in Firefox */
   font-family: var(--sb-main-font-family);
   font-size: 14px;
   background-color: var(--sb-main-bg-color);

--- a/public/popup.css
+++ b/public/popup.css
@@ -312,8 +312,11 @@
  */
 
 #mainControls {
-  flex-flow: column;
-  align-items: center;
+  margin-bottom: 12px;
+}
+
+.sponsorStartHint {
+  display: block;
   margin-bottom: 12px;
 }
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -89,6 +89,19 @@
 }
 
 /*
+ * Alert indicating that Beta server is enabled
+ */
+
+#sbBetaServerWarning {
+  padding: 8px;
+  font-size: 1em;
+  font-weight: 700;
+  color: var(--sb-main-fg-color);
+  background-color: var(--sb-red-bg-color);
+  cursor: pointer;
+}
+
+/*
  * Header logo
  */
 
@@ -554,14 +567,4 @@
 
 #sponsorBlockPopupBody .hidden {
   display: none !important;
-}
-
-#sbBetaServerWarning {
-  padding: 8px;
-  font-size: 1em;
-  font-weight: 700;
-  word-break: break-word;
-  color: var(--sb-main-fg-color);
-  background: var(--sb-red-bg-color);
-  cursor: pointer;
 }

--- a/public/popup.css
+++ b/public/popup.css
@@ -45,6 +45,7 @@
   text-align: center;
 }
 
+#sponsorblockPopup a,
 #sponsorblockPopup button {
   cursor: pointer;
 }
@@ -210,7 +211,6 @@
  */
 
 .toggleSwitchContainer {
-  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -297,11 +297,14 @@
  */
 
 #whitelistForceCheck {
-  font-weight: bold;
-  text-decoration: underline;
-  font-size: large;
-  cursor: pointer;
-  padding: 10px 0;
+  background-color: #fff3cd;
+  color: #664d03;
+  display: block;
+  padding: 10px 15px;
+}
+
+#whitelistForceCheck:hover {
+  background-color: #f2e4b7;
 }
 
 /*
@@ -511,7 +514,6 @@
 
 #sbFooter a {
   color: var(--sb-main-fg-color);
-  cursor: pointer;
   text-decoration: none;
 }
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -45,6 +45,10 @@
   text-align: center;
 }
 
+#sponsorblockPopup button {
+  cursor: pointer;
+}
+
 /*
  * Disable transition on all elements until the extension has loaded
  */
@@ -98,7 +102,6 @@
   background: transparent;
   border: 0;
   border-radius: 50%;
-  cursor: pointer;
   display: flex;
   padding: 5px;
   margin: 5px auto;
@@ -182,9 +185,8 @@
 }
 
 .sbControlsMenu-item {
-  background-color: var(--sb-grey-bg-color);
+  background: transparent;
   border: 0;
-  padding: 0;
   cursor: pointer;
   user-select: none;
   padding: 10px 15px;
@@ -323,7 +325,6 @@
   -webkit-border-radius: 28px;
   border-radius: 28px;
   display: inline-block;
-  cursor: pointer;
   color: var(--sb-main-fg-color);
   font-size: 16px;
   padding: 8px 37px;
@@ -381,11 +382,10 @@
  */
 
 #setUsernameButton,
-#submitUsername,
-#copyUserID {
+#copyUserID,
+#submitUsername {
   background: transparent;
   border: 0;
-  cursor: pointer;
   padding: 0;
   color: var(--sb-main-fg-color);
   width: fit-content;
@@ -524,7 +524,6 @@
   border: 1px solid #fff;
   border-radius: 5px;
   color: var(--sb-main-fg-color);
-  cursor: pointer;
   margin-bottom: 20px;
   padding: 5px;
 }

--- a/public/popup.html
+++ b/public/popup.html
@@ -68,7 +68,7 @@
         <p class="sbHeader">
           __MSG_recordTimesDescription__
         </p>
-        <sub style="margin-bottom: 12px;">__MSG_popupHint__</sub>
+        <sub class="sponsorStartHint">__MSG_popupHint__</sub>
         <div>
           <button id="sponsorStart" class="sbMediumButton">__MSG_sponsorStart__</button>
         </div>

--- a/public/popup.html
+++ b/public/popup.html
@@ -84,7 +84,7 @@
           <div>
             <p class="u-mZ">__MSG_Username__:</p>
             <div id="setUsernameContainer">
-              <p id="usernameValue" class="u-mZ"></p>
+              <p id="usernameValue"></p>
               <button id="setUsernameButton" title="__MSG_setUsername__">
                 <img src="/icons/pencil.svg" alt="__MSG_setUsername__" width="16" height="16" id="sbPopupIconEdit">
               </button>

--- a/public/popup.html
+++ b/public/popup.html
@@ -34,7 +34,7 @@
       </div>
 
       <div class="sbControlsMenu">
-        <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item" title="__MSG_forceChannelCheckPopup__">
+        <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item">
           <input type="checkbox" style="display:none;" id="whitelistToggle">
           <svg viewBox="0 0 24 24" width="23" height="23" class="SBWhitelistIcon sbControlsMenu-itemIcon">
             <path d="M24 10H14V0h-4v10H0v4h10v10h4V14h10z" />
@@ -60,9 +60,9 @@
         </button>
       </div>
 
-      <p id="whitelistForceCheck" class="u-mZ hidden">
+      <a id="whitelistForceCheck" class="hidden">
         __MSG_forceChannelCheckPopup__
-      </p>
+      </a>
 
       <div id="mainControls" style="display: none">
         <p class="sbHeader">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -691,6 +691,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                     PageElements.unwhitelistChannel.style.display = "unset";
                     document.querySelectorAll('.SBWhitelistIcon')[0].classList.add("rotated");
 
+                    //show 'consider force channel check' alert
                     if (!Config.config.forceChannelCheck) PageElements.whitelistForceCheck.classList.remove("hidden");
 
                     //save this
@@ -737,6 +738,9 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                     PageElements.whitelistChannel.style.display = "unset";
                     PageElements.unwhitelistChannel.style.display = "none";
                     document.querySelectorAll('.SBWhitelistIcon')[0].classList.remove("rotated");
+
+                    //hide 'consider force channel check' alert
+                    PageElements.whitelistForceCheck.classList.add("hidden");
 
                     //save this
                     Config.config.whitelistedChannels = whitelistedChannels;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -304,7 +304,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
         //if request is undefined, then the page currently being browsed is not YouTube
         if (request != undefined) {
             //remove loading text
-            PageElements.mainControls.style.display = "flex";
+            PageElements.mainControls.style.display = "block";
             if (request.onMobileYouTube) PageElements.mainControls.classList.add("hidden");
             PageElements.whitelistButton.classList.remove("hidden");
             PageElements.loadingIndicator.style.display = "none";


### PR DESCRIPTION
### Current Problem

- The "consider enabling force channel check" alert has wrapping text and pushes the content down quite a lot
- The alert doesn't disappear when the thing that triggered it is toggled off
- Couple minor spacing regressions in #1189
- Forced popup width causes horizontal scrollbar/misalignment in Firefox
- Lack of `max-height` can cause Firefox popup to be too large/cause scroll issues

### Proposed Solution

- Use colours instead of font size/weight to make the alert noticeable
- Hide the alert when "Remove channel from whitelist" is clicked
- Fix some spacing regressions
- Add `max-width: 100%` to fix Firefox popup width issues
- Add `max-height: 600px` (only in popup context) to fix Firefox popup height issues

This also tidies/simplifies the popup CSS a bit.

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/247634/159119032-d920194b-15ef-4c8c-b630-00166b7c09f5.gif)  |  ![after](https://user-images.githubusercontent.com/247634/159119039-27d8e1f1-e0db-47b0-b737-4db9a6d1c69d.gif)

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

closes #778
closes #1235