### PR TITLE
Improve the channel ID lookup.

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1120,11 +1120,12 @@ function updatePreviewBar(): void {
 async function whitelistCheck() {
     const whitelistedChannels = Config.config.whitelistedChannels;
 
-    const getChannelID = () => videoInfo?.videoDetails?.channelId
-        ?? document.querySelector(".ytd-channel-name a")?.getAttribute("href")?.replace(/\/.+\//, "") // YouTube
-        ?? document.querySelector(".ytp-title-channel-logo")?.getAttribute("href")?.replace(/https:\/.+\//, "") // YouTube Embed
-        ?? document.querySelector("a > .channel-profile")?.parentElement?.getAttribute("href")?.replace(/\/.+\//, "") // Invidious
-        ?? document.querySelector("a.slim-owner-icon-and-title")?.getAttribute("href")?.replace(/\/.+\//, ""); // Mobile YouTube
+    const getChannelID = () =>
+        (document.querySelector("a.ytd-video-owner-renderer") // YouTube
+        ?? document.querySelector("a.ytp-title-channel-logo") // YouTube Embed
+        ?? document.querySelector(".channel-profile #channel-name")?.parentElement.parentElement // Invidious
+        ?? document.querySelector("a.slim-owner-icon-and-title")) // Mobile YouTube
+            ?.getAttribute("href")?.match(/\/channel\/(UC[a-zA-Z0-9_-]{22})/)[1];
 
     try {
         await utils.wait(() => !!getChannelID(), 6000, 20);


### PR DESCRIPTION
Closes #1249. @mchangrh 

This PR:
- Fixes desktop YouTube channel ID lookup. Previously it would grab entries from the Home tab which could sometimes be open in the background, and this also caused channel custom URLs to sometimes be grabbed as well.
- Potentially makes the Invidious lookup more stable.
- Makes the Regex more strict and reliable.

The reason the Invidious lookup uses `.channel-profile #channel-name` instead of just `#channel-name` is because the YouTube desktop client also uses `#channel-name`, but has over 50 instances of it. The `.channel-profile` makes sure the Invidious selector cannot accidentally match the wrong element in the YouTube desktop client. (if for example the chained selectors were converted to a promise race in the future)

***

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0
