### PR TITLE
Implement Channel-Specific Category Selection

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -200,6 +200,9 @@
     "showDeleteButton": {
         "message": "Show Delete Button On YouTube Player"
     },
+    "removeChannelSettingsButton": {
+        "message": "Remove Channel-Specific Settings"
+    },
     "enableViewTracking": {
         "message": "Enable Skip Count Tracking"
     },
@@ -621,6 +624,9 @@
     "category_livestream_messages_short": {
         "message": "Message Reading"
     },
+    "inherit": {
+        "message": "Inherit"
+    },
     "autoSkip": {
         "message": "Auto Skip"
     },
@@ -737,8 +743,14 @@
     "whatForceChannelCheck": {
         "message": "By default, it will skip segments right away before it even knows what the channel is. By default, some segments at the start of the video might be skipped on whitelisted channels. Enabling this option will prevent this but making all skipping have a slight delay as getting the channelID can take some time. This delay might be unnoticeable if you have fast internet."
     },
+    "channelSettingsPopup": {
+        "message": "Ctrl-click to open the channel-specific settings for this channel."
+    },
     "forceChannelCheckPopup": {
         "message": "Consider Enabling \"Force Channel Check Before Skipping\""
+    },
+    "forceChannelCheckRequired": {
+        "message": "\"Force Channel Check Before Skipping\" is required for channel-specific category selections to work properly."
     },
     "downvoteDescription": {
         "message": "Incorrect/Wrong Timing"

--- a/public/options/options.css
+++ b/public/options/options.css
@@ -558,6 +558,10 @@ svg {
 
 /* React styles */
 
+.categoryTableHeader {
+    height: 3em; /* So the height doesn't change when switching to/from global channel settings (which have two-line headers) */
+}
+
 .categoryTableElement {
     font-size: 16px;
 }

--- a/public/popup.html
+++ b/public/popup.html
@@ -30,7 +30,7 @@
       </div>
 
       <div class="sbControlsMenu">
-        <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item" title="__MSG_forceChannelCheckPopup__">
+        <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item" title="__MSG_channelSettingsPopup__">
           <input type="checkbox" style="display:none;" id="whitelistToggle">
           <svg viewBox="0 0 24 24" width="23" height="23" class="SBWhitelistIcon sbControlsMenu-itemIcon">
             <path d="M24 10H14V0h-4v10H0v4h10v10h4V14h10z" />

--- a/src/components/CategoryChooserComponent.tsx
+++ b/src/components/CategoryChooserComponent.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
 
 import * as CompileConfig from "../../config.json";
-import { Category } from "../types";
+import { Category, CategorySkipOption } from "../types";
 import CategorySkipOptionsComponent from "./CategorySkipOptionsComponent";
+import Config from "../config";
 
 export interface CategoryChooserProps { 
 
 }
 
 export interface CategoryChooserState {
-
+    selectedChannel: string
 }
 
 class CategoryChooserComponent extends React.Component<CategoryChooserProps, CategoryChooserState> {
@@ -17,20 +18,30 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
     constructor(props: CategoryChooserProps) {
         super(props);
 
+        // Set the selected channel from the part of the document hash after the slash
+        const hashSlashIndex = document.location.hash.indexOf("/");
+        let selectedChannel = hashSlashIndex > -1 ? document.location.hash.slice(hashSlashIndex + 1) : null;
+
+        const channelSpecificSettings = Config.config.channelSpecificSettings;
+        if (channelSpecificSettings[selectedChannel] == undefined)
+            selectedChannel = null;
+
         // Setup state
         this.state = {
-            
+            selectedChannel: selectedChannel
         }
     }
 
     render(): React.ReactElement {
         return (
-            <table id="categoryChooserTable"
-                className="categoryChooserTable"> 
-                <tbody>
+            <>
+                {this.getChannelSettings()}
+                <table id="categoryChooserTable"
+                       className="categoryChooserTable">
+                    <tbody>
                     {/* Headers */}
                     <tr id={"CategoryOptionsRow"}
-                            className="categoryTableElement categoryTableHeader">
+                        className="categoryTableElement categoryTableHeader">
                         <th id={"CategoryOptionName"}>
                             {chrome.i18n.getMessage("category")}
                         </th>
@@ -40,20 +51,73 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
                             {chrome.i18n.getMessage("skipOption")}
                         </th>
 
-                        <th id={"CategoryColorOption"}
-                            className="colorOption">
-                            {chrome.i18n.getMessage("seekBarColor")}
-                        </th>
+                        { // Colour options are only available when configuring global skip settings
+                            this.state.selectedChannel == null &&
+                            <>
+                                <th id={"CategoryColorOption"}
+                                    className="colorOption">
+                                    {chrome.i18n.getMessage("seekBarColor")}
+                                </th>
 
-                        <th id={"CategoryPreviewColorOption"}
-                            className="previewColorOption">
-                            {chrome.i18n.getMessage("previewColor")}
-                        </th>
+                                <th id={"CategoryPreviewColorOption"}
+                                    className="previewColorOption">
+                                    {chrome.i18n.getMessage("previewColor")}
+                                </th>
+                            </>
+                        }
                     </tr>
 
                     {this.getCategorySkipOptions()}
-                </tbody> 
-            </table>
+                    </tbody>
+                </table>
+            </>
+        );
+    }
+
+    // Renders the channel chooser and associated buttons
+    getChannelSettings(): JSX.Element {
+        const channelSpecificSettings = Config.config.channelSpecificSettings;
+        const channelOptions = [];
+        for (const channelID in channelSpecificSettings) {
+            channelOptions.push({
+                name: channelSpecificSettings[channelID].name,
+                element: <option value={channelID}>{
+                    channelSpecificSettings[channelID].name ? channelSpecificSettings[channelID].name : channelID
+                }</option>
+            });
+        }
+        channelOptions.sort((a, b) => {
+            return ('' + a.name).localeCompare(b.name);
+        });
+
+        return (
+            <>
+                <select id="channelChooser"
+                        className="optionsSelector inline"
+                        style={{verticalAlign: "middle"}}
+                        defaultValue={this.state.selectedChannel == null ? "global" : this.state.selectedChannel}
+                        onChange={this.channelSelected.bind(this)}>
+                    <option value="global">- Global Settings -</option>
+                    {channelOptions.map((channelOption) => { return channelOption.element; })}
+                </select>
+                {
+                    this.state.selectedChannel != null &&
+                    <>
+                        <div id="removeChannelSelections"
+                            className="option-button inline"
+                            style={{marginLeft: "5px", padding: "5px", verticalAlign: "middle"}}
+                            onClick={this.removeSelectedChannel.bind(this)}>
+                            {chrome.i18n.getMessage("removeChannelSettingsButton")}
+                        </div>
+                        {
+                            !Config.config.forceChannelCheck &&
+                            <span className="inline"
+                                  style={{marginLeft: "5px"}}>
+                                {chrome.i18n.getMessage("forceChannelCheckRequired")}</span>
+                        }
+                    </>
+                }
+            </>
         );
     }
 
@@ -63,12 +127,32 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
         for (const category of CompileConfig.categoryList) {
             elements.push(
                 <CategorySkipOptionsComponent category={category as Category}
+                    selectedChannel={this.state.selectedChannel}
                     key={category}>
                 </CategorySkipOptionsComponent>
             );
         }
 
         return elements;
+    }
+
+    // Called when a channel is selected in the channel chooser
+    channelSelected(event: React.ChangeEvent<HTMLSelectElement>): void {
+        if (event.target.value == "global") {
+            document.location.hash = "behavior";
+            this.setState({selectedChannel: null});
+        } else {
+            document.location.hash = "behavior/" + event.target.value;
+            this.setState({selectedChannel: event.target.value});
+        }
+    }
+
+    // Removes *all* the selected channel's settings from `channelSpecificSettings`
+    removeSelectedChannel(): void {
+        delete Config.config.channelSpecificSettings[this.state.selectedChannel];
+        this.setState({selectedChannel: null});
+
+        Config.config.channelSpecificSettings = Config.config.channelSpecificSettings;
     }
 }
 

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -13,7 +13,7 @@ interface DefaultMessage {
         "update"
         | "sponsorStart"
         | "getVideoID"
-        | "getChannelID"
+        | "getChannelInfo"
         | "isChannelWhitelisted"
         | "submitTimes"
         | "refreshSegments";
@@ -53,8 +53,9 @@ interface GetVideoIdResponse {
     videoID: string;
 }
 
-interface GetChannelIDResponse {
+interface GetChannelInfoResponse {
     channelID: string;
+    channelName: string;
 }
 
 interface SponsorStartResponse {
@@ -68,7 +69,7 @@ interface IsChannelWhitelistedResponse {
 export type MessageResponse = 
     IsInfoFoundMessageResponse
     | GetVideoIdResponse
-    | GetChannelIDResponse
+    | GetChannelInfoResponse
     | SponsorStartResponse
     | IsChannelWhitelistedResponse
     | Record<string, never>

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,8 +22,9 @@ async function init() {
 
     // selected tab
     if (location.hash != "") {
-        const substr = location.hash.slice(1);
-        let menuItem = document.querySelector(`[data-for='${substr}']`);
+        const slashIndex = location.hash.indexOf("/");
+        const tabName = location.hash.slice(1, slashIndex > -1 ? slashIndex : undefined);
+        let menuItem = document.querySelector(`[data-for='${tabName}']`);
         if (menuItem == null)
             menuItem = document.querySelector(`[data-for='behavior']`);
         menuItem.classList.add("selected");
@@ -648,7 +649,7 @@ function copyDebugOutputToClipboard() {
     output.config.serverAddress = (output.config.serverAddress === CompileConfig.serverAddress) 
         ? "Default server address" : "Custom server address";
     output.config.invidiousInstances = output.config.invidiousInstances.length;
-    output.config.whitelistedChannels = output.config.whitelistedChannels.length;
+    output.config.channelSpecificSettings = output.config.channelSpecificSettings.length;
 
     // Copy object to clipboard
     navigator.clipboard.writeText(JSON.stringify(output, null, 4))

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface VideoDurationResponse {
 }
 
 export enum CategorySkipOption {
+    Disabled = -1,
     ShowOverlay,
     ManualSkip,
     AutoSkip
@@ -199,7 +200,14 @@ export enum ChannelIDStatus {
 
 export interface ChannelIDInfo {
     id: string,
+    name: string,
     status: ChannelIDStatus
+}
+
+export interface ChannelSpecificSettings {
+    name: string,
+    whitelisted: boolean,
+    categorySelections: CategorySelection[]
 }
 
 export interface SkipToTimeParams {


### PR DESCRIPTION
Adds channel-specific category selection, and makes the improvements necessary under the hood to make it possible.
This PR was created with a lot of @mchangrh's help. Thank you.

This adds ctrl-click functionality to the whitelist button in the popup. This opens channel-specific settings and creates a new channel entry if it's not present.

In order for this to work properly, it *requires* the `Force Channel Check Before Skipping` option to be enabled.

This was my first time working with TypeScript and React, so please let me know if I've done something incorrectly.

This PR is the reason for #1249 and #1250.

## Notes
This PR makes the following changes to support channel-specific categories:
1. Removes the `whitelistedChannels` config property, integrates channel whitelisting with the new `channelSpecificSettings` property, and migrates old configs to the new format.
2. Adds a new `Disabled` enum option for `CategorySkipOption`, which is set to `-1`. (so it doesn't mess up existing option values stored in configs)
   This was required so that categories could be disabled for specific channels, since previously the extension disabled categories by removing them from the list. (which doesn't work for inherited values)
3. Fetches the channel name at the same time as when it fetches the channel ID. This is used for display in the channel dropdown.
4. The *Behavior* table header now has a defined height, so it doesn't change height when the two-line colour headings disappear.
5. The hover text for the whitelist button in the popup has been changed, since there's already a notice when a channel is first whitelisted.
6. Fixes a bug I found where `shouldSkip` would return true for full-video segments on music videos if `autoSkipOnMusicVideos` was enabled.

## New Localisation Values
The following values are new and at the moment only have `en` localisation keys:
- `removeChannelSettingsButton`: The label of the button for removing channel-specific settings.
- `inherit`: The `Inherit` skip option for channel-specific category selections.
- `channelSettingsPopup`: The hover text for the whitelist button that mentions to Ctrl-click the button for channel-specific settings.
- `forceChannelCheckRequired`: The warning that channel-specific settings don't work properly if `Force Channel Check Before Skipping` is not enabled.

## Known Jank
1. More could probably be done to tell the user about the ctrl-click functionality, but I felt this was a good start.
2. In the *Behavior* tab, scroll up the page a bit. Select a channel in the dropdown - the page will not scroll or move. If you now select the Global settings again, the page does scroll.
It's the inconsistency that bothers me, not the scrolling.
I have a feeling it's something to do with React DOM updates related to the re-appearing colour selection elements, but I'm not sure how or why.

***

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).
