### PR TITLE
Start playback of edited segment at it's end when it starts 0:00

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -532,6 +532,11 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
         const index = this.props.index;
 
         const skipTime = sponsorTimes[index].segment[0];
+        // If segment starts at 0:00, start playback at the end of the segment
+        if (skipTime === 0) {
+            this.props.contentContainer().previewTime(sponsorTimes[index].segment[1]);
+            return;
+        }
 
         let seekTime = 2;
         if (ctrlPressed) seekTime = 0.5;


### PR DESCRIPTION
This PR makes the `Preview` button in the segment editing component start video playback at the segment's end if the segment starts exactly at `0:00`.
This basically fixes a minor annoyance that I (and possibly others) had when trying to fine-tune a segment starting at `0:00` - the first frame of the video flashing for a "second".
~~Also WebStorm decided to remove a bunch of whitespace from the file, I hope that doesn't cause too many issues. The main code edits start at line 535.~~ Changes undone

I've tested this pull request and it seems to be working as intended.
***
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).