### PR TITLE
Fix vote button hover inconsistency

### DIFF
--- a/public/content.css
+++ b/public/content.css
@@ -9,7 +9,7 @@
     position: absolute;
     width: 100%;
 	pointer-events: none;
-	
+
 	height: 100%;
 	transform: scaleY(0.6) translateY(-30%) translateY(1.5px);
 	z-index: 40;
@@ -108,7 +108,7 @@
 
 .sponsorSkipObject {
 	font-family: Roboto, Arial, Helvetica, sans-serif;
-		
+
 	margin-left: 2px;
 	margin-right: 2px;
 }
@@ -253,7 +253,7 @@
 .sponsorSkipNoticeButton:hover {
 	background-color: rgba(235, 235, 235,0.2);
 	border-radius: 4px;
-	
+
 	transition: background-color 0.4s;
 }
 
@@ -288,7 +288,7 @@
 	height: 10px;
 	width: 10px;
 	box-sizing: unset;
-	
+
 	padding: 2px 5px;
 
 	margin-left: 2px;
@@ -303,7 +303,7 @@
 	font-size: 14px;
 	font-weight: bold;
 	color: rgb(235, 235, 235);
-	
+
 	margin-top: auto;
 	display: inline-block;
 	margin-right: 10px;
@@ -343,15 +343,6 @@
     color: rgb(235, 235, 235);
 }
 
-.voteButton {
-	height: 24px;
-	width: 24px;
-	cursor: pointer;
-}
-.voteButton:hover {
-	filter: brightness(80%);
-}
-
 .segmentSummary {
 	outline: none !important;
 }
@@ -369,7 +360,7 @@
 	padding:4px 15px;
 	text-decoration:none;
     text-shadow:0px 0px 0px #662727;
-    
+
     margin-top: 5px;
     margin-right: 15px;
 }
@@ -405,7 +396,7 @@
 	padding:4px 15px;
 	text-decoration:none;
     text-shadow:0px 0px 0px #662727;
-    
+
     margin-top: 5px;
     margin-right: 15px;
 }
@@ -467,7 +458,7 @@
 	margin-right: 20px;
 
 	font-size: 13px;
-	
+
 	cursor: pointer;
 }
 
@@ -516,14 +507,14 @@ input::-webkit-inner-spin-button {
 	height: 25px;
 	cursor: pointer;
 	padding: 5px;
-	
+
 	margin: auto;
     top: 0;
     bottom: 0;
     position: absolute;
 }
 .helpButton:hover {
-	filter: brightness(80%);
+	opacity: 0.8;
 }
 
 .sbChatNotice iframe {
@@ -646,7 +637,7 @@ input::-webkit-inner-spin-button {
 	height: 10px;
 	width: 10px;
 	box-sizing: unset;
-	
+
 	margin: 0px 0px 0px 5px;
 }
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -190,6 +190,10 @@
   cursor: pointer;
 }
 
+.voteButton:hover {
+  opacity: 0.8;
+}
+
 /*
  * "Voted!" text that appears after voting on a segment
  */


### PR DESCRIPTION
### Current Problem

If you hover over a segment's voting buttons when the popup is rendered in-page, they slightly reduce in opacity.

But if you hover over the voting buttons when the popup is rendered in the dropdown, they do not change in opacity.

This difference in behaviour based on where the popup is rendered looks like a bug to me.

### Proposed Solution

Fix this by removing `.voteButton` CSS from `content.css` and adding the missing `.voteButton:hover` CSS to `popup.css`

Also:
- Prefer `opacity` over `filter` for changing opacity

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/247634/164910484-336d59e1-6301-4dc7-9a91-34dbb7c27595.gif)  |  ![after](https://user-images.githubusercontent.com/247634/164910492-14e29325-69a4-4066-9d81-6cbd70bcf596.gif)

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***