### PR TITLE
Implement Custom Channel Overrides

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -119,32 +119,32 @@
         "message": "Are you sure you want to submit this?"
     },
     "whitelistChannel": {
-         "message": "Whitelist channel"
+        "message": "Whitelist channel"
     },
     "removeFromWhitelist": {
-         "message": "Remove channel from whitelist"
+        "message": "Remove channel from whitelist"
     },
     "voteOnTime": {
-         "message": "Vote On A Segment"
+        "message": "Vote On A Segment"
     },
     "Submissions": {
-         "message": "Submissions"
+        "message": "Submissions"
     },
     "savedPeopleFrom": {
-         "message": "You've saved people from "
+        "message": "You've saved people from "
     },
     "viewLeaderboard": {
-         "message": "Leaderboard"
+        "message": "Leaderboard"
     },
     "recordTimesDescription": {
-         "message": "Submit"
+        "message": "Submit"
     },
     "submissionEditHint": {
         "message": "Section editing will appear after you click submit",
         "description": "Appears in the popup to inform them that editing has been moved to the video player."
     },
     "popupHint": {
-         "message": "Hint: You can setup keybinds for submitting in the options"
+        "message": "Hint: You can setup keybinds for submitting in the options"
     },
     "clearTimesButton": {
         "message": "Clear Times"
@@ -300,6 +300,12 @@
     },
     "enableSkipping": {
         "message": "Skipping is disabled"
+    },
+    "disableChannelOverrides": {
+        "message": "Channel Overrides are enabled"
+    },
+    "enableChannelOverrides": {
+        "message": "Channel Overrides are disabled"
     },
     "yourWork": {
         "message": "Your Work",
@@ -948,7 +954,7 @@
     "FullDetails": {
         "message": "Full Details"
     },
-	"CopyDownvoteButtonInfo": {
+    "CopyDownvoteButtonInfo": {
         "message": "Downvotes and creates a local copy for you to resubmit"
     },
     "OpenCategoryWikiPage": {

--- a/public/popup.css
+++ b/public/popup.css
@@ -13,15 +13,18 @@
 .grey-text {
   color: var(--sb-grey-fg-color);
 }
+
 .white-text {
   color: var(--sb-main-fg-color);
 }
+
 .sbHeader {
   font-size: 20px;
   font-weight: bold;
   text-align: left;
   margin: 0;
 }
+
 #sponsorBlockPopupBody .u-mZ {
   margin: 0 !important;
   position: relative;
@@ -34,15 +37,15 @@
 /*
  * <button> elements that have icons
  */
- #setUsernameButton,
- #copyUserID,
- #submitUsername {
-   color: var(--sb-main-fg-color);
-   background: transparent;
-   width: fit-content;
-   padding: none;
-   border: none;
- }
+#setUsernameButton,
+#copyUserID,
+#submitUsername {
+  color: var(--sb-main-fg-color);
+  background: transparent;
+  width: fit-content;
+  padding: none;
+  border: none;
+}
 
 /*
  * Main containers
@@ -56,7 +59,8 @@
 #sponsorBlockPopupBody {
   margin: 0;
   width: 374px;
-  max-width: 100%; /* NOTE: Ensures content doesn't exceed restricted popup widths in Firefox */
+  max-width: 100%;
+  /* NOTE: Ensures content doesn't exceed restricted popup widths in Firefox */
   font-size: 14px;
   font-family: var(--sb-main-font-family);
   background-color: var(--sb-main-bg-color);
@@ -144,6 +148,7 @@
   padding: 10px 0px 0px;
   font-size: 32px;
 }
+
 .sbPopupLogo img {
   margin: 8px;
 }
@@ -160,6 +165,7 @@
   border: none;
   padding: 5px;
 }
+
 #refreshSegmentsButton:hover {
   background-color: var(--sb-grey-bg-color);
 }
@@ -172,9 +178,11 @@
   border-radius: 8px;
   margin: 4px 16px;
 }
+
 .votingButtons[open] {
   padding-bottom: 5px;
 }
+
 .votingButtons:hover {
   background-color: var(--sb-grey-bg-color);
 }
@@ -192,21 +200,25 @@
   cursor: pointer;
   padding: 4px 8px;
 }
-.segmentSummary > div {
+
+.segmentSummary>div {
   text-align: left;
 }
+
 /*
  * Category dot in segment
  */
 .sponsorTimesCategoryColorCircle {
   margin-right: 8px;
 }
+
 .dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
   display: inline-block;
 }
+
 /* 
  * Category name in segment
  */
@@ -251,6 +263,7 @@
   overflow: hidden;
   display: flex;
 }
+
 .sbControlsMenu-item {
   display: flex;
   align-items: center;
@@ -264,9 +277,11 @@
   padding: 10px 15px;
   trasition: background-color 0.2s ease-in-out;
 }
+
 .sbControlsMenu-item:hover {
   background-color: #444;
 }
+
 .sbControlsMenu-itemIcon {
   margin-bottom: 6px;
 }
@@ -274,16 +289,19 @@
 /*
  * Whitelist add/remove icon
  */
-.SBWhitelistIcon > path {
+.SBWhitelistIcon>path {
   fill: var(--sb-main-fg-color);
 }
+
 .SBWhitelistIcon.rotated {
   transform: rotate(45deg);
 }
+
 @keyframes rotate {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -297,31 +315,37 @@
   align-items: center;
   flex-direction: column;
 }
+
 .toggleSwitchContainer-switch {
   display: flex;
   margin-bottom: 6px;
 }
+
 .switchBg {
   width: 50px;
   height: 23px;
   display: block;
   border-radius: 18.5px;
 }
+
 .switchBg.shadow {
   box-shadow: 0.75px 0.75px 10px 0px rgba(50, 50, 50, 0.5);
   opacity: 1;
 }
+
 .switchBg.white {
   opacity: 1;
   position: absolute;
   background-color: #ccc;
 }
+
 .switchBg.green {
   opacity: 0;
   position: absolute;
   background-color: #00a205;
   transition: opacity 0.2s ease-out;
 }
+
 .switchDot {
   width: 15px;
   margin: 4px;
@@ -332,15 +356,52 @@
   background-color: var(--sb-main-fg-color);
   box-shadow: 0.75px 0.75px 3.8px 0px rgba(50, 50, 50, 0.45);
 }
-#toggleSwitch:checked ~ .switchDot {
+
+#toggleSwitch:checked~.switchDot {
   transform: translateX(27px);
 }
-#toggleSwitch:checked ~ .switchBg.green {
+
+#toggleSwitch:checked~.switchBg.green {
   opacity: 1;
 }
-#toggleSwitch:checked ~ .switchBg.white {
+
+#toggleSwitch:checked~.switchBg.white {
   transition: opacity 0.2s step-end;
   opacity: 0;
+}
+
+/*
+ * "Channel Overrides are enabled" toggle
+ */
+#channelOverridesToggleSwitch:checked~.switchDot {
+  transform: translateX(27px);
+}
+
+#channelOverridesToggleSwitch:checked~.switchBg.green {
+  opacity: 1;
+}
+
+#channelOverridesToggleSwitch:checked~.switchBg.white {
+  transition: opacity 0.2s step-end;
+  opacity: 0;
+}
+
+#channelOverridesList {
+  margin: 16px;
+  margin-top: 0;
+  padding: 8px 12px;
+  text-align: left;
+  border-radius: 8px;
+  border: 2px solid var(--sb-grey-bg-color);
+}
+
+.popupCategory {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-weight: bold;
+  font-size: 14px;
 }
 
 /*
@@ -353,6 +414,7 @@
   display: block;
   color: #664d03;
 }
+
 #whitelistForceCheck:hover {
   background-color: #f2e4b7;
 }
@@ -367,6 +429,7 @@
   border-radius: 8px;
   border: 2px solid var(--sb-grey-bg-color);
 }
+
 .sponsorStartHint {
   display: block;
   text-align: left;
@@ -388,15 +451,18 @@
   font-family: var(--sb-main-font-family);
   background-color: var(--sb-red-bg-color);
 }
+
 .sbMediumButton:hover,
 .sbMediumButton:focus {
   background-color: #ec1c1c;
   outline: none;
 }
+
 .sbMediumButton:active {
   position: relative;
   top: 1px;
 }
+
 /*
  * "Submit Times" button
  */
@@ -413,7 +479,8 @@
   border-radius: 8px;
   border: 2px solid var(--sb-grey-bg-color);
 }
-.sbYourWorkCols > div {
+
+.sbYourWorkCols>div {
   display: flex;
   border-top: 2px solid var(--sb-grey-bg-color);
   border-bottom: 2px solid var(--sb-grey-bg-color);
@@ -437,7 +504,8 @@
   font-size: 16px;
   flex: 1 0;
 }
- /*
+
+/*
  * Improve alignment of username and submissions
  */
 #usernameElement,
@@ -446,7 +514,8 @@
   flex-direction: column;
   justify-content: start;
 }
-#usernameElement > span,
+
+#usernameElement>span,
 #sponsorTimesContributionsContainer {
   text-align: start;
 }
@@ -464,24 +533,30 @@
   padding: 8px;
   min-width: 50%;
 }
+
 #setUsernameContainer {
   display: flex;
   width: fit-content;
 }
-#setUsernameContainer > button {
+
+#setUsernameContainer>button {
   display: flex;
 }
+
 #setUsernameButton {
   margin-right: 5px;
   flex: 0 1;
 }
+
 #submitUsername {
   padding-left: 16px;
 }
+
 #copyUserID {
   width: 100%;
   flex: 0 1;
 }
+
 /*
  * Truncate username display
  */
@@ -492,12 +567,14 @@
   margin: 0 8px 0 0;
   max-width: 130px;
 }
+
 /*
  * Set username form container with "expanded" state
  */
 #setUsername.SBExpanded {
   text-align: left;
 }
+
 /*
  * Set username input
  */
@@ -524,6 +601,7 @@
 #sbFooter {
   padding: 8px 0;
 }
+
 #sbFooter a {
   transition: background 0.3s ease !important;
   color: var(--sb-main-fg-color);
@@ -536,6 +614,7 @@
   font-weight: 500;
   margin: 2px 1px;
 }
+
 #sbFooter a:hover {
   background: #444;
 }

--- a/public/popup.html
+++ b/public/popup.html
@@ -71,7 +71,7 @@
       </a>
 
       <!-- Channel Overrides Box -->
-      <!--github: scaccoman/channel-overrides-->
+      <!--github: scaccoman/SponsorBlock-->
       <div class="sbControlsMenu">
         <label id="channelOverrides" for="channelOverridesToggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
         <span class="toggleSwitchContainer-switch">

--- a/public/popup.html
+++ b/public/popup.html
@@ -70,6 +70,27 @@
         __MSG_forceChannelCheckPopup__
       </a>
 
+      <!-- Channel Overrides Box -->
+      <!--github: scaccoman/channel-overrides-->
+      <div class="sbControlsMenu">
+        <label id="channelOverrides" for="channelOverridesToggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
+        <span class="toggleSwitchContainer-switch">
+          <input type="checkbox" style="display:none;" id="channelOverridesToggleSwitch" checked>
+          <span class="switchBg shadow"></span>
+          <span class="switchBg white"></span>
+          <span class="switchBg green"></span>
+          <span class="switchDot"></span>
+        </span>
+        <span id="disableChannelOverrides">__MSG_disableChannelOverrides__</span>
+        <span id="enableChannelOverrides" style="display: none">__MSG_enableChannelOverrides__</span>
+      </div>
+
+      <!-- Channel Overrides Container -->
+      <div id="channelOverridesContainer" style="display: none">
+        <ul id="channelOverridesList">
+        </ul>
+      </div>
+
       <!-- Submit box -->
       <div id="mainControls" style="display: none">
         <p class="sbHeader">

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ interface SBConfig {
     submissionCountSinceCategories: number, // New count used to show the "Read The Guidelines!!" message
     showTimeWithSkips: boolean,
     disableSkipping: boolean,
+    channelOverrides: any, // todo: define type!
     muteSegments: boolean,
     fullVideoSegments: boolean,
     trackViewCount: boolean,
@@ -138,6 +139,7 @@ const Config: SBObject = {
         submissionCountSinceCategories: 0,
         showTimeWithSkips: true,
         disableSkipping: false,
+        channelOverrides: {},
         muteSegments: true,
         fullVideoSegments: true,
         trackViewCount: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as CompileConfig from "../config.json";
 import * as invidiousList from "../ci/invidiouslist.json";
-import { Category, CategorySelection, CategorySkipOption, NoticeVisbilityMode, PreviewBarOption, SponsorTime, StorageChangesObject, Keybind, HashedValue, VideoID, SponsorHideType, ChannelOverride, ChannelIDInfo } from "./types";
+import { Category, CategorySelection, CategorySkipOption, NoticeVisbilityMode, PreviewBarOption, SponsorTime, StorageChangesObject, Keybind, HashedValue, VideoID, SponsorHideType, ChannelOverride } from "./types";
 import { keybindEquals } from "./utils/configUtils";
 
 interface SBConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as CompileConfig from "../config.json";
 import * as invidiousList from "../ci/invidiouslist.json";
-import { Category, CategorySelection, CategorySkipOption, NoticeVisbilityMode, PreviewBarOption, SponsorTime, StorageChangesObject, Keybind, HashedValue, VideoID, SponsorHideType } from "./types";
+import { Category, CategorySelection, CategorySkipOption, NoticeVisbilityMode, PreviewBarOption, SponsorTime, StorageChangesObject, Keybind, HashedValue, VideoID, SponsorHideType, ChannelOverride, ChannelIDInfo } from "./types";
 import { keybindEquals } from "./utils/configUtils";
 
 interface SBConfig {
@@ -17,7 +17,7 @@ interface SBConfig {
     submissionCountSinceCategories: number, // New count used to show the "Read The Guidelines!!" message
     showTimeWithSkips: boolean,
     disableSkipping: boolean,
-    channelOverrides: any, // todo: define type!
+    channelOverrides: Record<string, ChannelOverride>,
     muteSegments: boolean,
     fullVideoSegments: boolean,
     trackViewCount: boolean,

--- a/src/content.ts
+++ b/src/content.ts
@@ -84,8 +84,6 @@ let lastCheckVideoTime = -1;
 
 //is this channel whitelised from getting sponsors skipped
 let channelWhitelisted = false;
-//enable custom channel overrides
-let channelOverridesEnabled = false;
 
 let previewBar: PreviewBar = null;
 // Skip to highlight button
@@ -276,7 +274,6 @@ function resetValues() {
 
     videoInfo = null;
     channelWhitelisted = false;
-    channelOverridesEnabled = false;
     channelIDInfo = {
         status: ChannelIDStatus.Fetching,
         id: null

--- a/src/content.ts
+++ b/src/content.ts
@@ -84,6 +84,8 @@ let lastCheckVideoTime = -1;
 
 //is this channel whitelised from getting sponsors skipped
 let channelWhitelisted = false;
+//enable custom channel overrides
+let channelOverridesEnabled = false;
 
 let previewBar: PreviewBar = null;
 // Skip to highlight button
@@ -274,6 +276,7 @@ function resetValues() {
 
     videoInfo = null;
     channelWhitelisted = false;
+    channelOverridesEnabled = false;
     channelIDInfo = {
         status: ChannelIDStatus.Fetching,
         id: null
@@ -562,7 +565,7 @@ function startSponsorSchedule(includeIntersectingSegments = false, currentTime?:
                 openNotice: skipInfo.openNotice
             });
 
-            if (utils.getCategorySelection(currentSkip.category)?.option === CategorySkipOption.ManualSkip
+            if (utils.getSkipOption(currentSkip.category, channelIDInfo.id)?.option === CategorySkipOption.ManualSkip
                     || currentSkip.actionType === ActionType.Mute) {
                 forcedSkipTime = skipTime[0] + 0.001;
             } else {
@@ -986,7 +989,7 @@ function startSkipScheduleCheckingForStartSponsors() {
             .filter((time) => time.segment[1] > video.currentTime && time.actionType === ActionType.Poi)
             .sort((a, b) => b.segment[0] - a.segment[0]);
         for (const time of poiSegments) {
-            const skipOption = utils.getCategorySelection(time.category)?.option;
+            const skipOption = utils.getSkipOption(time.category, channelIDInfo.id)?.option;
             if (skipOption !== CategorySkipOption.ShowOverlay) {
                 skipToTime({
                     v: video,
@@ -1501,14 +1504,14 @@ function createButton(baseID: string, title: string, callback: () => void, image
 }
 
 function shouldAutoSkip(segment: SponsorTime): boolean {
-    return utils.getCategorySelection(segment.category)?.option === CategorySkipOption.AutoSkip ||
+    return utils.getSkipOption(segment.category, channelIDInfo.id)?.option === CategorySkipOption.AutoSkip ||
             (Config.config.autoSkipOnMusicVideos && sponsorTimes?.some((s) => s.category === "music_offtopic")
                 && segment.actionType !== ActionType.Poi);
 }
 
 function shouldSkip(segment: SponsorTime): boolean {
     return (segment.actionType !== ActionType.Full
-            && utils.getCategorySelection(segment.category)?.option !== CategorySkipOption.ShowOverlay)
+            && utils.getSkipOption(segment.category, channelIDInfo.id)?.option !== CategorySkipOption.ShowOverlay)
             || (Config.config.autoSkipOnMusicVideos && sponsorTimes?.some((s) => s.category === "music_offtopic"));
 }
 

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -17,7 +17,7 @@ interface DefaultMessage {
         | "isChannelWhitelisted"
         | "submitTimes"
         | "refreshSegments"
-        | "closePopup";
+        | "closePopup"
 }
 
 interface BoolValueMessage {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -2,7 +2,7 @@ import Config from "./config";
 import * as CompileConfig from "../config.json";
 
 import Utils from "./utils";
-import { SponsorTime, SponsorHideType, ActionType, StorageChangesObject, Category, CategorySkipOption } from "./types";
+import { SponsorTime, SponsorHideType, ActionType, StorageChangesObject } from "./types";
 import { Message, MessageResponse, IsInfoFoundMessageResponse } from "./messageTypes";
 import { showDonationLink } from "./utils/configUtils";
 import { AnimationUtils } from "./utils/animationUtils";

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,3 +231,8 @@ export type Keybind = {
     alt?: boolean,
     shift?: boolean
 }
+
+export type ChannelOverride = {
+    enabled?: boolean,
+    categories?: Record<Category, number>
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import Config, { VideoDownvotes } from "./config";
-import { CategorySelection, SponsorTime, FetchResponse, BackgroundScriptContainer, Registration, HashedValue, VideoID, SponsorHideType } from "./types";
+import { Category, CategorySelection, SponsorTime, FetchResponse, BackgroundScriptContainer, Registration, HashedValue, VideoID, SponsorHideType } from "./types";
 
 import * as CompileConfig from "../config.json";
 import { findValidElementFromSelector } from "./utils/pageUtils";
@@ -248,12 +248,28 @@ export default class Utils {
         return sponsorTimes[this.getSponsorIndexFromUUID(sponsorTimes, UUID)];
     }
 
-    getCategorySelection(category: string): CategorySelection {
+    /**
+     * Returns a category selection shaped override configuration for a given channel ID.
+     */
+    getChannelOverrideSelection(category: Category, channelID: string): CategorySelection {
+        if (channelID && Config.config.channelOverrides[channelID]?.enabled === true) {
+            const override = Config.config.channelOverrides[channelID].categories?.[category];
+            if (override !== undefined && override !== null && override !== 0) {
+                return { name: category, option: override - 1 };
+            }
+        }
+    }
+
+    getCategorySelection(category: Category): CategorySelection {
         for (const selection of Config.config.categorySelections) {
             if (selection.name === category) {
                 return selection;
             }
         }
+    }
+
+    getSkipOption(category: Category, channelID: string): CategorySelection {
+        return this.getChannelOverrideSelection(category, channelID) || this.getCategorySelection(category);
     }
 
     /**


### PR DESCRIPTION
This PR implements new custom channel override logic, which seems to be one of the most requested features:
- https://github.com/ajayyy/SponsorBlock/issues/435
- https://github.com/ajayyy/SponsorBlock/issues/1308
- https://github.com/ajayyy/SponsorBlock/issues/1251
- https://github.com/ajayyy/SponsorBlock/issues/1085
- https://github.com/ajayyy/SponsorBlock/issues/646

<img width="364" alt="Screenshot 2022-06-27 at 17 47 54" src="https://user-images.githubusercontent.com/28684618/175993550-0a146df1-700b-47ff-bc1c-bd7f8ede0034.png">

Please see the attached screen recording for a brief demo:
https://user-images.githubusercontent.com/28684618/175990993-94e62021-bdc4-4309-960b-8730cd4bd097.mp4


There are some weird behaviours around `disabled` segment types, I'm not really sure how it's supposed to work. I would appreciate it if someone more familiar with the project (e.g. @ajayyy) could shed some light.

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0