### PR TITLE
fix embeds not being detected correctly

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -100,7 +100,10 @@ const playerButtons: Record<string, {button: HTMLButtonElement, image: HTMLImage
 // Direct Links after the config is loaded
 utils.wait(() => Config.config !== null, 1000, 1).then(() => videoIDChange(getYouTubeVideoID(document)));
 // wait for hover preview to appear, and refresh attachments if ever found
-window.addEventListener("DOMContentLoaded", () => utils.waitForElement(".ytp-inline-preview-ui").then(() => refreshVideoAttachments()));
+window.addEventListener("DOMContentLoaded", () => {
+    utils.waitForElement(".ytp-inline-preview-ui").then(() => refreshVideoAttachments())
+    utils.waitForElement("[data-sessionlink='feature=player-title']").then(() => videoIDChange(getYouTubeVideoID(document)))
+});
 addPageListeners();
 addHotkeyListener();
 
@@ -206,6 +209,9 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
             submitSponsorTimes();
             break;
         case "refreshSegments":
+            // update video on refresh if videoID invalid
+            if (!sponsorVideoID) videoIDChange(getYouTubeVideoID(document));
+            // fetch segments
             sponsorsLookup(false).then(() => sendResponse({
                 found: sponsorDataFound,
                 status: lastResponseStatus,


### PR DESCRIPTION
- add awaiter for key element
- refresh ID with segments if videoID is invalid

closes #1386 

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
