### PR TITLE
Add "start" button to select start of video as segment start

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -762,6 +762,9 @@
     "bracketNow": {
         "message": "(Now)"
     },
+    "bracketStart": {
+        "message": "(Start)"
+    },
     "moreCategories": {
         "message": "More Categories"
     },

--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -115,7 +115,11 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                 <div id={"sponsorTimesContainer" + this.idSuffix}
                     style={timeDisplayStyle}
                     className="sponsorTimeDisplay">
-
+                        <span id={"nowButton0" + this.idSuffix}
+                            className="sponsorNowButton"
+                            onClick={() => this.setTimeToStart()}>
+                                {chrome.i18n.getMessage("bracketStart")}
+                        </span>
                         <span id={"nowButton0" + this.idSuffix}
                             className="sponsorNowButton"
                             onClick={() => this.setTimeToNow(0)}>
@@ -451,6 +455,10 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
 
     setTimeToNow(index: number): void {
         this.setTimeTo(index, this.props.contentContainer().getRealCurrentTime());
+    }
+
+    setTimeToStart(): void {
+        this.setTimeTo(0, 0);
     }
 
     setTimeToEnd(): void {

--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -115,7 +115,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                 <div id={"sponsorTimesContainer" + this.idSuffix}
                     style={timeDisplayStyle}
                     className="sponsorTimeDisplay">
-                        <span id={"nowButton0" + this.idSuffix}
+                        <span id={"startButton" + this.idSuffix}
                             className="sponsorNowButton"
                             onClick={() => this.setTimeToStart()}>
                                 {chrome.i18n.getMessage("bracketStart")}


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

Hi, this feature can be used to mark start of the video with a click (similar to the "end" to mark end of video to be the end of segment). Usually I come across segments that start from 0:00.234 or similar because that's when the person clicked on segment start, when they actually meant it to be on 0:00.000.

I have a couple of questions:

1. My UI was messed for a very short time. This could be because I have a very narrow Firefox window, but maybe worth getting feedback on.

![now-ui-messed](https://user-images.githubusercontent.com/432489/179421050-7c5b552d-b461-4d98-a63b-1b2e134ee31f.png)
![now-ui-proper](https://user-images.githubusercontent.com/432489/179421051-d73d3fe1-71f1-4a03-ac7f-e8775fb79941.png)

2. How to add locales? I added for English manually, but is there an easy way to add them for all languages?