### PR TITLE
don't show unskip first for full size notices

### DIFF
--- a/src/components/SkipNoticeComponent.tsx
+++ b/src/components/SkipNoticeComponent.tsx
@@ -265,7 +265,7 @@ class SkipNoticeComponent extends React.Component<SkipNoticeProps, SkipNoticeSta
 
                 {/* Unskip/Skip Button */}
                 {!this.props.smaller || this.segments[0].actionType === ActionType.Mute
-                    ? this.getSkipButton(1) : null}
+                    ? this.getSkipButton(0) : null}
 
                 {/* Never show button */}
                 {!this.autoSkip || this.props.startReskip ? "" :


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

closes #1421 

doesn't seem to be done intentionally, likely just an overlooked regression