### PR TITLE
update wording of Preview to be inline with wiki

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -637,7 +637,7 @@
         "message": "Preview/Recap"
     },
     "category_preview_description": {
-        "message": "Collection of clips that show what is coming up in other videos of the series without voice-over or text overlays that provide additional context."
+        "message": "Collection of clips that show what is coming up in in this video or other videos in a series where all information is repeated later in the video."
     },
     "category_preview_guideline1": {
         "message": "Clips that appear later, or in a future video"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -637,7 +637,7 @@
         "message": "Preview/Recap"
     },
     "category_preview_description": {
-        "message": "Quick recap of previous episodes, or a preview of what's coming up later in the current video. Meant for edited together clips, not for spoken summaries."
+        "message": "Collection of clips that show what is coming up in other videos of the series without voice-over or text overlays that provide additional context."
     },
     "category_preview_guideline1": {
         "message": "Clips that appear later, or in a future video"


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

after some discussion in the discord, it was revealed that the description in the extension did not match what the current guidelines were for previews