### PR TITLE
Tidy/simplify popup

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -122,6 +122,9 @@
     "closePopup": {
         "message": "Close Popup"
     },
+    "closeIcon": {
+        "message": "Close Icon"
+    },
     "SubmitTimes": {
         "message": "Submit Segments"
     },

--- a/public/popup.css
+++ b/public/popup.css
@@ -403,7 +403,7 @@
  */
 #mainControls {
   margin: 16px;
-  padding: 8px 12px;
+  padding: 8px 14px;
   text-align: left;
   border-radius: 8px;
   border: 2px solid var(--sb-grey-bg-color);
@@ -411,6 +411,7 @@
 .sponsorStartHint {
   display: block;
   text-align: left;
+  padding-top: 3px;
 }
 
 /*
@@ -448,24 +449,24 @@
 /*
  * Your Work box
  */
-.sbYourWorkCols {
+.sbYourWorkBox {
   margin: 16px;
   margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid var(--sb-grey-bg-color);
 }
-.sbYourWorkCols > div {
-  display: flex;
+.sbYourWorkCols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   border-top: 2px solid var(--sb-grey-bg-color);
   border-bottom: 2px solid var(--sb-grey-bg-color);
 }
 
 .sbStatsSentence {
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 6px 14px;
 }
 
-.sbStatsSentence .sbExtraInfo {
+.sbExtraInfo {
   display: inline-block;
 }
 
@@ -473,37 +474,26 @@
  * Increase font size of username input and display
  */
 #usernameValue,
-#usernameInput,
-#sponsorTimesContributionsDisplay {
+#usernameInput {
   font-size: 16px;
   flex: 1 0;
+}
+#sponsorTimesContributionsDisplay {
+  font-size: 16px;
 }
  /*
  * Improve alignment of username and submissions
  */
-#usernameElement,
+#usernameElement > p,
 #sponsorTimesContributionsContainer {
-  display: flex;
-  flex-direction: column;
-  justify-content: start;
-}
-#usernameElement > span,
-#sponsorTimesContributionsContainer {
-  text-align: start;
-}
-
-#sponsorTimesContributionsContainer {
-  margin-left: 8px;
-  padding-left: 8px;
-  border-left: 2px solid var(--sb-grey-bg-color);
+  text-align: left;
 }
 
 /*
  * Username
  */
 #usernameElement {
-  padding: 8px;
-  min-width: 50%;
+  padding: 8px 14px;
 }
 #setUsernameContainer {
   display: flex;
@@ -549,14 +539,15 @@
   width: calc(100% - 68px);
   text-overflow: ellipsis;
   color: var(--sb-main-fg-color);
-  background: var(--sb-grey-bg-color);
+  background-color: var(--sb-grey-bg-color);
 }
 
 /*
  * Submissions
 */
 #sponsorTimesContributionsContainer {
-  padding: 8px;
+  padding: 8px 14px;
+  border-left: 2px solid var(--sb-grey-bg-color);
 }
 
 /*
@@ -571,14 +562,13 @@
   display: inline-block;
   text-decoration: none;
   border-radius: 4px;
-  background: #333;
-  cursor: pointer;
+  background-color: #333;
   padding: 4px 8px;
   font-weight: 500;
   margin: 2px 1px;
 }
 #sbFooter a:hover {
-  background: #444;
+  background-color: #444;
 }
 
 #sponsorTimesDonateContainer a {

--- a/public/popup.css
+++ b/public/popup.css
@@ -456,8 +456,7 @@
   border: 2px solid var(--sb-grey-bg-color);
 }
 .sbYourWorkCols {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
   border-top: 2px solid var(--sb-grey-bg-color);
   border-bottom: 2px solid var(--sb-grey-bg-color);
 }
@@ -494,6 +493,8 @@
  */
 #usernameElement {
   padding: 8px 14px;
+  min-width: 50%;
+  width: 100%;
 }
 #setUsernameContainer {
   display: flex;

--- a/public/popup.html
+++ b/public/popup.html
@@ -13,7 +13,7 @@
     <div id="sponsorblockPopup" class="sponsorBlockPageBody sb-preload">
 
       <button id="sbCloseButton" title="__MSG_closePopup__" class="sbCloseButton hidden">
-        <img src="icons/close.png" width="15" height="15">
+        <img src="icons/close.png" width="15" height="15" alt="Close icon">
       </button>
 
       <div id="sbBetaServerWarning" class="hidden" title="__MSG_openOptionsPage__">
@@ -24,7 +24,7 @@
         <img src="icons/IconSponsorBlocker256px.png" alt="SponsorBlock" width="40" height="40" id="sponsorBlockPopupLogo">
         <p class="u-mZ">SponsorBlock</p>
       </header>
-      
+
       <div id="videoInfo">
         <!-- Loading text -->
         <p id="loadingIndicator" class="u-mZ grey-text">__MSG_noVideoID__</p>
@@ -64,11 +64,11 @@
           </div>
         </div>
       </div>
-      
+
       <!-- Toggle Box -->
       <div class="sbControlsMenu">
         <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item">
-          <input type="checkbox" style="display:none;" id="whitelistToggle">
+          <input type="checkbox" style="display: none" id="whitelistToggle">
           <svg viewBox="0 0 24 24" width="23" height="23" class="SBWhitelistIcon sbControlsMenu-itemIcon">
             <path d="M24 10H14V0h-4v10H0v4h10v10h4V14h10z" />
           </svg>
@@ -78,7 +78,7 @@
         <!--github: mbledkowski/toggle-switch-->
         <label id="disableExtension" for="toggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
           <span class="toggleSwitchContainer-switch">
-            <input type="checkbox" style="display:none;" id="toggleSwitch" checked>
+            <input type="checkbox" style="display: none" id="toggleSwitch" checked>
             <span class="switchBg shadow"></span>
             <span class="switchBg white"></span>
             <span class="switchBg green"></span>
@@ -99,29 +99,29 @@
 
       <!-- Submit box -->
       <div id="mainControls" style="display: none">
-        <p class="sbHeader">
+        <h1 class="sbHeader">
           __MSG_recordTimesDescription__
-        </p>
+        </h1>
         <sub class="sponsorStartHint grey-text">__MSG_popupHint__</sub>
-        <div align="center" style="margin: 8px 0;">  
+        <div style="text-align: center; margin: 8px 0;">
           <button id="sponsorStart" class="sbMediumButton" style="margin-right: 8px">__MSG_sponsorStart__</button>
-          <button id="submitTimes" class="sbMediumButton" style="display: none;">__MSG_submitTimesButton__</button>
+          <button id="submitTimes" class="sbMediumButton" style="display: none">__MSG_submitTimesButton__</button>
         </div>
-        <span id="submissionHint" style="display: none;">__MSG_submissionEditHint__</span>
+        <span id="submissionHint" style="display: none">__MSG_submissionEditHint__</span>
       </div>
 
       <!-- Your Work box -->
-      <div class="sbYourWorkCols">
-        <p class="sbHeader" style="padding: 8px 16px;">
+      <div class="sbYourWorkBox">
+        <h1 class="sbHeader" style="padding: 8px 15px;">
           __MSG_yourWork__
-        </p>
-        <div>
+        </h1>
+        <div class="sbYourWorkCols">
           <!-- Username -->
           <div id="usernameElement">
-            <span class="u-mZ grey-text">__MSG_Username__:
+            <p class="u-mZ grey-text">__MSG_Username__:
               <!-- loading/errors -->
               <span id="setUsernameStatus" class="u-mZ white-text" style="display: none"></span>
-            </span>
+            </p>
             <div id="setUsernameContainer">
               <p id="usernameValue"></p>
               <button id="setUsernameButton" title="__MSG_setUsername__">
@@ -141,7 +141,7 @@
           <!-- Submissions -->
           <div id="sponsorTimesContributionsContainer" class="hidden">
             <p class="u-mZ grey-text">__MSG_Submissions__:</p>
-            <span id="sponsorTimesContributionsDisplay">0</span>
+            <p id="sponsorTimesContributionsDisplay" class="u-mZ">0</p>
           </div>
         </div>
 

--- a/public/popup.html
+++ b/public/popup.html
@@ -184,7 +184,7 @@
         <a id="sbConsiderDonateLink" href="https://sponsor.ajay.app/donate" target="_blank" rel="noopener">
           __MSG_considerDonating__
         </a>
-        <img id="sbCloseDonate" src="/icons/close.png" alt="Close icon" height="8" style="padding-left: 5px; cursor: pointer;" />
+        <img id="sbCloseDonate" src="/icons/close.png" alt="__MSG_closeIcon__" height="8" style="padding-left: 5px; cursor: pointer;" />
       </div>
 
       <footer id="sbFooter">


### PR DESCRIPTION
### Current Problem

Looks like lots of tweaks have happened to the popup, but there's various alignment issues, invalid HTML such as missing `alt` attribute, use of old `align` attribute etc.

### Proposed Solution

Somewhat tidy up the popup HTML and CSS. Improves alignment/padding, reduces unnecessary flexbox usage, ~fixes "Your Work" not having equal columns~ etc.

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![before](https://i.imgur.com/E8c3BG9.png)  |  ![after](https://i.imgur.com/JCNZKS1.png)

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).