### PR TITLE
Fix popup width when embedded in page

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -100,6 +100,10 @@
   margin-bottom: 16px;
 }
 
+#sponsorBlockPopupContainer iframe {
+  width: 100%;
+}
+
 /*
  * Disable popup max height when displayed in-page (content.ts)
  */
@@ -110,7 +114,7 @@
 /*
  * Disable fixed popup width when displayed in-page (content.ts)
  */
-#sponsorBlockPopupContainer #sponsorBlockPopupBody {
+#sponsorBlockPopupBody.is-embedded {
   width: auto;
 }
 
@@ -207,7 +211,7 @@
   border-radius: 50%;
   display: inline-block;
 }
-/* 
+/*
  * Category name in segment
  */
 .summaryLabel {
@@ -511,7 +515,7 @@
   background: var(--sb-grey-bg-color);
 }
 
-/* 
+/*
  * Submissions
 */
 #sponsorTimesContributionsContainer {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -75,6 +75,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
     const PageElements: PageElements = {};
 
     [
+        "sponsorBlockPopupBody",
         "sponsorblockPopup",
         "sponsorStart",
         // Top toggles
@@ -132,7 +133,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
 
     getSegmentsFromContentScript(false);
     await utils.wait(() => Config.config !== null && allowPopup, 5000, 5);
-    document.querySelector("body").style.removeProperty("visibility");
+    PageElements.sponsorBlockPopupBody.style.removeProperty("visibility");
     if (!Config.configSyncListeners.includes(contentConfigUpdateListener)) {
         Config.configSyncListeners.push(contentConfigUpdateListener);
     }
@@ -145,6 +146,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
 
     if (window !== window.top) {
         PageElements.sbCloseButton.classList.remove("hidden");
+        PageElements.sponsorBlockPopupBody.classList.add("is-embedded");
     }
 
     // Hide donate button if wanted (Safari, or user choice)
@@ -187,7 +189,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
     if (window !== window.top) {
         document.addEventListener("keydown", (e) => {
             const target = e.target as HTMLElement;
-            if (target.tagName === "INPUT" 
+            if (target.tagName === "INPUT"
                 || target.tagName === "TEXTAREA"
                 || e.key === "ArrowUp"
                 || e.key === "ArrowDown") {
@@ -255,7 +257,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                 }
                 PageElements.sponsorTimesOthersTimeSavedDisplay.innerText = getFormattedHours(minutesSaved);
             }
-            
+
             Config.config.isVip = userInfo.vip;
         }
     });
@@ -489,7 +491,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                 }
 
                 segmentTimeFromToNode.style.margin = "5px";
-                
+
                 // for inline-styling purposes
                 const labelContainer = document.createElement("div");
                 labelContainer.appendChild(categoryColorCircle);


### PR DESCRIPTION
### Current Problem

Looks like the "popup embedded in the YouTube sidebar" was moved to an `<iframe>` in #1322.

This broke a CSS selector which was there to remove the fixed `width` from the popup when it's embedded in the page:

https://github.com/ajayyy/SponsorBlock/blob/780ea4a9d0b12762d10e787786816e3e8a6f9b26/public/popup.css#L113-L115

_(this was added in #1228)_

Because this selector no longer works, when the popup is rendered in the YouTube sidebar it does not fill the full width.

### Proposed Solution

Add `.is-embedded` class to the `<body id="sponsorBlockPopupBody">` element when it is rendered in the page.

This is then used in the CSS to replace the broken selector.

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![before](https://i.imgur.com/3QLbh3d.png)  |  ![after](https://i.imgur.com/eeYJ0eS.png)

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).