### PR TITLE
Improve copy of start/end segment button

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -77,10 +77,10 @@
         "message": "No segments found"
     },
     "sponsorStart": {
-        "message": "Segment Starts Now"
+        "message": "Start Segment Now"
     },
     "sponsorEnd": {
-        "message": "Segment Ends Now"
+        "message": "End Segment Now"
     },
     "sponsorCancel": {
         "message": "Cancel Creating Segment"

--- a/public/popup.css
+++ b/public/popup.css
@@ -377,7 +377,7 @@
 }
 
 /*
- * Generic buttons used for "Segment Starts Now" and "Submit Times"
+ * Generic red buttons used for "Start Segment Now", "Submit Times" etc.
  */
 .sbMediumButton {
   border: none;


### PR DESCRIPTION
### Current Problem

Ever since using this (excellent) extension the labelling of the main "Segment Starts Now" button has irked me 🙂 

Button labels should typically start with a verb i.e. the "action" that will be performed - "Start" in this case. Right now in both "states" of the button, the label starts with a noun - "Segment" in this case.

User shouldn't need to read somewhere in the middle of the button to determine the "state" the button is in.

### Proposed Solution

- `Segment Starts Now` -> `Start Segment Now`
- `Segment Ends Now` -> `End Segment Now`

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![before](https://i.imgur.com/y2RAEkC.png)  |  ![after](https://i.imgur.com/Ybkd0ny.png)

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).