### PR TITLE
Update popup on segment updates + some code cleanup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2,13 +2,13 @@ import * as CompileConfig from "../config.json";
 
 import Config from "./config";
 import { Registration } from "./types";
-import Utils from "./utils";
-import { GenericUtils } from "./utils/genericUtils";
 
 // Make the config public for debugging purposes
 
 window.SB = Config;
 
+import Utils from "./utils";
+import { GenericUtils } from "./utils/genericUtils";
 const utils = new Utils({
     registerFirefoxContentScript,
     unregisterFirefoxContentScript

--- a/src/background.ts
+++ b/src/background.ts
@@ -107,6 +107,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
         }
         case "time":
         case "infoUpdated":
+        case "videoChanged":
             if (sender.tab) {
                 popupPort[sender.tab.id]?.postMessage(request);
             }

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,13 +2,13 @@ import * as CompileConfig from "../config.json";
 
 import Config from "./config";
 import { Registration } from "./types";
+import Utils from "./utils";
+import { GenericUtils } from "./utils/genericUtils";
 
 // Make the config public for debugging purposes
 
 window.SB = Config;
 
-import Utils from "./utils";
-import { GenericUtils } from "./utils/genericUtils";
 const utils = new Utils({
     registerFirefoxContentScript,
     unregisterFirefoxContentScript
@@ -24,7 +24,7 @@ if (utils.isFirefox()) {
     utils.wait(() => Config.config !== null).then(function() {
         if (Config.config.supportInvidious) utils.setupExtraSiteContentScripts();
     });
-} 
+}
 
 function onTabUpdatedListener(tabId: number) {
     chrome.tabs.sendMessage(tabId, {
@@ -77,17 +77,17 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
                     ok: response.ok
                 });
             });
-        
+
             return true;
         case "submitVote":
             submitVote(request.type, request.UUID, request.category).then(callback);
-        
+
             //this allows the callback to be called later
             return true;
-        case "registerContentScript": 
+        case "registerContentScript":
             registerFirefoxContentScript(request);
             return false;
-        case "unregisterContentScript": 
+        case "unregisterContentScript":
             unregisterFirefoxContentScript(request.id)
             return false;
         case "tabs": {
@@ -106,6 +106,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
             return true;
         }
         case "time":
+        case "infoUpdated":
             if (sender.tab) {
                 popupPort[sender.tab.id]?.postMessage(request);
             }
@@ -156,8 +157,8 @@ chrome.runtime.onInstalled.addListener(function () {
 /**
  * Only works on Firefox.
  * Firefox requires that it be applied after every extension restart.
- * 
- * @param {JSON} options 
+ *
+ * @param {JSON} options
  */
 function registerFirefoxContentScript(options: Registration) {
     const oldRegistration = contentScriptRegistrations[options.id];
@@ -174,7 +175,7 @@ function registerFirefoxContentScript(options: Registration) {
 /**
  * Only works on Firefox.
  * Firefox requires that this is handled by the background script
- * 
+ *
  */
 function unregisterFirefoxContentScript(id: string) {
     contentScriptRegistrations[id].unregister();
@@ -225,10 +226,10 @@ async function asyncRequestToServer(type: string, address: string, data = {}) {
 
 /**
  * Sends a request to the specified url
- * 
+ *
  * @param type The request type "GET", "POST", etc.
  * @param address The address to add to the SponsorBlock server address
- * @param callback 
+ * @param callback
  */
 async function sendRequestToCustomServer(type: string, url: string, data = {}) {
     // If GET, convert JSON to parameters

--- a/src/content.ts
+++ b/src/content.ts
@@ -384,7 +384,7 @@ function resetValues() {
     categoryPill?.setVisibility(false);
 }
 
-async function videoIDChange(id): Promise<void> {
+async function videoIDChange(id: string): Promise<void> {
     // don't switch to invalid value
     if (!id && sponsorVideoID && !document?.URL?.includes("youtube.com/clip/")) return;
     //if the id has not changed return unless the video element has changed
@@ -441,7 +441,7 @@ async function videoIDChange(id): Promise<void> {
     //close popup
     closeInfoMenu();
 
-    sponsorsLookup(id);
+    sponsorsLookup();
 
     // Make sure all player buttons are properly added
     updateVisibilityOfPlayerControlsButton();
@@ -1219,12 +1219,12 @@ function startSkipScheduleCheckingForStartSponsors() {
     }
 }
 
-function getYouTubeVideoID(document: Document, url?: string): string | boolean {
+function getYouTubeVideoID(document: Document, url?: string): string {
     url ||= document.URL;
     // pageType shortcut
-    if (pageType === PageType.Channel) return getYouTubeVideoIDFromDocument()
+    if (pageType === PageType.Channel) return getYouTubeVideoIDFromDocument();
     // clips should never skip, going from clip to full video has no indications.
-    if (url.includes("youtube.com/clip/")) return false;
+    if (url.includes("youtube.com/clip/")) return null;
     // skip to document and don't hide if on /embed/
     if (url.includes("/embed/") && url.includes("youtube.com")) return getYouTubeVideoIDFromDocument(false, PageType.Embed);
     // skip to URL if matches youtube watch or invidious or matches youtube pattern
@@ -1235,7 +1235,7 @@ function getYouTubeVideoID(document: Document, url?: string): string | boolean {
     return getYouTubeVideoIDFromURL(url) || getYouTubeVideoIDFromDocument(false);
 }
 
-function getYouTubeVideoIDFromDocument(hideIcon = true, pageHint = PageType.Watch): string | boolean {
+function getYouTubeVideoIDFromDocument(hideIcon = true, pageHint = PageType.Watch): string {
     const selector = "a.ytp-title-link[data-sessionlink='feature=player-title']";
     // get ID from document (channel trailer / embedded playlist)
     const element = pageHint === PageType.Embed ? document.querySelector(selector)
@@ -1247,11 +1247,11 @@ function getYouTubeVideoIDFromDocument(hideIcon = true, pageHint = PageType.Watc
         pageType = pageHint;
         return getYouTubeVideoIDFromURL(videoURL);
     } else {
-        return false;
+        return null;
     }
 }
 
-function getYouTubeVideoIDFromURL(url: string): string | boolean {
+function getYouTubeVideoIDFromURL(url: string): string {
     if(url.startsWith("https://www.youtube.com/tv#/")) url = url.replace("#", "");
 
     //Attempt to parse url
@@ -1260,7 +1260,7 @@ function getYouTubeVideoIDFromURL(url: string): string | boolean {
         urlObject = new URL(url);
     } catch (e) {
         console.error("[SB] Unable to parse URL: " + url);
-        return false;
+        return null;
     }
 
     // Check if valid hostname
@@ -1274,7 +1274,7 @@ function getYouTubeVideoIDFromURL(url: string): string | boolean {
             utils.wait(() => Config.config !== null).then(() => videoIDChange(getYouTubeVideoIDFromURL(url)));
         }
 
-        return false;
+        return null;
     } else {
         onInvidious = false;
     }
@@ -1282,17 +1282,17 @@ function getYouTubeVideoIDFromURL(url: string): string | boolean {
     //Get ID from searchParam
     if (urlObject.searchParams.has("v") && ["/watch", "/watch/"].includes(urlObject.pathname) || urlObject.pathname.startsWith("/tv/watch")) {
         const id = urlObject.searchParams.get("v");
-        return id.length == 11 ? id : false;
+        return id.length == 11 ? id : null;
     } else if (urlObject.pathname.startsWith("/embed/") || urlObject.pathname.startsWith("/shorts/")) {
         try {
             const id = urlObject.pathname.split("/")[2]
             if (id?.length >=11 ) return id.slice(0, 11);
         } catch (e) {
             console.error("[SB] Video ID not valid for " + url);
-            return false;
+            return null;
         }
     }
-    return false;
+    return null;
 }
 
 /**

--- a/src/content.ts
+++ b/src/content.ts
@@ -215,7 +215,6 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
         case "getVideoID":
             sendResponse({
                 videoID: sponsorVideoID,
-                creatingSegment: isSegmentCreationInProgress(),
             });
 
             break;
@@ -243,15 +242,9 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
             // update video on refresh if videoID invalid
             if (!sponsorVideoID) videoIDChange(getYouTubeVideoID(document));
             // fetch segments
-            sponsorsLookup(false).then(() => sendResponse({
-                found: sponsorDataFound,
-                status: lastResponseStatus,
-                sponsorTimes: sponsorTimes,
-                time: video.currentTime,
-                onMobileYouTube
-            }));
+            sponsorsLookup(false);
 
-            return true;
+            break;
         case "unskip":
             unskipSponsorTime(sponsorTimes.find((segment) => segment.UUID === request.UUID), null, true);
             break;
@@ -437,6 +430,13 @@ async function videoIDChange(id: string): Promise<void> {
             utils.wait(getControls).then(createPreviewBar);
         }
     }
+
+    // Notify the popup about the video change
+    chrome.runtime.sendMessage({
+        message: "videoChanged",
+        videoID: sponsorVideoID,
+        whitelisted: channelWhitelisted
+    });
 
     sponsorsLookup();
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -1004,6 +1004,14 @@ async function sponsorsLookup(keepOldSubmissions = true) {
                     ?.sort((a, b) => a.segment[0] - b.segment[0]);
         if (!recievedSegments || !recievedSegments.length) {
             // return if no video found
+            chrome.runtime.sendMessage({
+                message: "infoUpdated",
+                found: false,
+                status: lastResponseStatus,
+                sponsorTimes: sponsorTimes,
+                time: video.currentTime,
+                onMobileYouTube
+            });
             retryFetch(404);
             return;
         }
@@ -1093,6 +1101,16 @@ async function sponsorsLookup(keepOldSubmissions = true) {
 
     importExistingChapters(true);
 
+    // notify popup of segment changes
+    chrome.runtime.sendMessage({
+        message: "infoUpdated",
+        found: sponsorDataFound,
+        status: lastResponseStatus,
+        sponsorTimes: sponsorTimes,
+        time: video.currentTime,
+        onMobileYouTube
+    });
+
     if (Config.config.isVip) {
         lockedCategoriesLookup();
     }
@@ -1138,8 +1156,8 @@ async function lockedCategoriesLookup(): Promise<void> {
 }
 
 function retryFetch(errorCode: number): void {
-    if (!Config.config.refetchWhenNotFound) return;
     sponsorDataFound = false;
+    if (!Config.config.refetchWhenNotFound) return;
 
     if (retryFetchTimeout) clearTimeout(retryFetchTimeout);
     if ((errorCode !== 404 && retryCount > 1) || (errorCode !== 404 && retryCount > 10)) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -438,9 +438,6 @@ async function videoIDChange(id: string): Promise<void> {
         }
     }
 
-    //close popup
-    closeInfoMenu();
-
     sponsorsLookup();
 
     // Make sure all player buttons are properly added
@@ -1812,7 +1809,8 @@ async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
     updateEditButtonsOnPlayer();
 
     // Don't show the info button on embeds
-    if (Config.config.hideInfoButtonPlayerControls || document.URL.includes("/embed/") || onInvidious) {
+    if (Config.config.hideInfoButtonPlayerControls || document.URL.includes("/embed/") || onInvidious
+        || document.getElementById("sponsorBlockPopupContainer") != null) {
         playerButtons.info.button.style.display = "none";
     } else {
         playerButtons.info.button.style.removeProperty("display");

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -9,7 +9,7 @@ interface BaseMessage {
 }
 
 interface DefaultMessage {
-    message: 
+    message:
         "update"
         | "sponsorStart"
         | "getVideoID"
@@ -95,7 +95,7 @@ interface IsChannelWhitelistedResponse {
     value: boolean;
 }
 
-export type MessageResponse = 
+export type MessageResponse =
     IsInfoFoundMessageResponse
     | GetVideoIdResponse
     | GetChannelIDResponse
@@ -120,4 +120,8 @@ export interface TimeUpdateMessage {
     time: number;
 }
 
-export type PopupMessage = TimeUpdateMessage;
+export type InfoUpdatedMessage = IsInfoFoundMessageResponse & {
+    message: "infoUpdated";
+}
+
+export type PopupMessage = TimeUpdateMessage | InfoUpdatedMessage;

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -83,15 +83,15 @@ interface GetVideoIdResponse {
     videoID: string;
 }
 
-interface GetChannelIDResponse {
+export interface GetChannelIDResponse {
     channelID: string;
 }
 
-interface SponsorStartResponse {
+export interface SponsorStartResponse {
     creatingSegment: boolean;
 }
 
-interface IsChannelWhitelistedResponse {
+export interface IsChannelWhitelistedResponse {
     value: boolean;
 }
 
@@ -111,7 +111,7 @@ export interface VoteResponse {
     responseText: string;
 }
 
-export interface ImportSegmentsResponse {
+interface ImportSegmentsResponse {
     importedSegments: SponsorTime[];
 }
 

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -124,4 +124,10 @@ export type InfoUpdatedMessage = IsInfoFoundMessageResponse & {
     message: "infoUpdated";
 }
 
-export type PopupMessage = TimeUpdateMessage | InfoUpdatedMessage;
+export interface VideoChangedPopupMessage {
+    message: "videoChanged";
+    videoID: string;
+    whitelisted: boolean;
+}
+
+export type PopupMessage = TimeUpdateMessage | InfoUpdatedMessage | VideoChangedPopupMessage;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,8 +1,21 @@
 import Config from "./config";
 
 import Utils from "./utils";
-import { SponsorTime, SponsorHideType, ActionType, SegmentUUID, SponsorSourceType, StorageChangesObject } from "./types";
-import { Message, MessageResponse, IsInfoFoundMessageResponse, ImportSegmentsResponse, PopupMessage } from "./messageTypes";
+import {
+    ActionType,
+    SegmentUUID,
+    SponsorHideType,
+    SponsorSourceType,
+    SponsorTime,
+    StorageChangesObject,
+} from "./types";
+import {
+    ImportSegmentsResponse,
+    IsInfoFoundMessageResponse,
+    Message,
+    MessageResponse,
+    PopupMessage,
+} from "./messageTypes";
 import { showDonationLink } from "./utils/configUtils";
 import { AnimationUtils } from "./utils/animationUtils";
 import { GenericUtils } from "./utils/genericUtils";
@@ -11,6 +24,7 @@ import { localizeHtmlPage } from "./utils/pageUtils";
 import { exportTimes } from "./utils/exporter";
 import GenericNotice from "./render/GenericNotice";
 import { noRefreshFetchingChaptersAllowed } from "./utils/licenseKey";
+
 const utils = new Utils();
 
 interface MessageListener {
@@ -188,7 +202,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
     }
 
     PageElements.exportSegmentsButton.addEventListener("click", exportSegments);
-    PageElements.importSegmentsButton.addEventListener("click", 
+    PageElements.importSegmentsButton.addEventListener("click",
         () => PageElements.importSegmentsMenu.classList.toggle("hidden"));
     PageElements.importSegmentsSubmit.addEventListener("click", importSegments);
 
@@ -260,7 +274,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
     if (dontShowNotice != undefined && dontShowNotice) {
         PageElements.showNoticeAgain.style.display = "unset";
     }
-    
+
     const values = ["userName", "viewCount", "minutesSaved", "vip", "permissions"];
     if (!Config.config.payments.freeAccess && !noRefreshFetchingChaptersAllowed()) values.push("freeChaptersAccess");
 
@@ -427,13 +441,10 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             PageElements.loadingIndicator.style.display = "none";
 
             downloadedTimes = request.sponsorTimes ?? [];
+            displayDownloadedSponsorTimes(downloadedTimes, request.time);
             if (request.found) {
                 PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsorFound");
-
                 PageElements.issueReporterImportExport.classList.remove("hidden");
-                if (request.sponsorTimes) {
-                    displayDownloadedSponsorTimes(request.sponsorTimes, request.time);
-                }
             } else if (request.status == 404 || request.status == 200) {
                 PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsor404");
                 PageElements.issueReporterImportExport.classList.remove("hidden");
@@ -514,7 +525,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             PageElements.issueReporterTabs.classList.add("hidden");
             currentSegmentTab = SegmentTab.Segments;
         } else {
-            if (currentSegmentTab === SegmentTab.Segments 
+            if (currentSegmentTab === SegmentTab.Segments
                     && sponsorTimes.every((segment) => segment.actionType === ActionType.Chapter)) {
                 PageElements.issueReporterTabs.classList.add("hidden");
                 currentSegmentTab = SegmentTab.Chapters;
@@ -529,7 +540,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                 if (currentSegmentTab === SegmentTab.Segments) {
                     return segment.actionType !== ActionType.Chapter;
                 } else if (currentSegmentTab === SegmentTab.Chapters) {
-                    return segment.actionType === ActionType.Chapter 
+                    return segment.actionType === ActionType.Chapter
                         && segment.source !== SponsorSourceType.YouTube;
                 } else {
                     return true;
@@ -546,7 +557,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
 
         if (downloadedTimes.length > 0) {
             PageElements.exportSegmentsButton.classList.remove("hidden");
-        } else { 
+        } else {
             PageElements.exportSegmentsButton.classList.add("hidden");
         }
 
@@ -590,7 +601,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             if (downloadedTimes[i].actionType === ActionType.Full) {
                 segmentTimeFromToNode.innerText = chrome.i18n.getMessage("full");
             } else {
-                segmentTimeFromToNode.innerText = GenericUtils.getFormattedTime(downloadedTimes[i].segment[0], true) + 
+                segmentTimeFromToNode.innerText = GenericUtils.getFormattedTime(downloadedTimes[i].segment[0], true) +
                         (actionType !== ActionType.Poi
                             ? " " + chrome.i18n.getMessage("to") + " " + GenericUtils.getFormattedTime(downloadedTimes[i].segment[1], true)
                             : "");
@@ -695,7 +706,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             skipButton.id = "sponsorTimesSkipButtonContainer" + UUID;
             skipButton.className = "voteButton";
             skipButton.src = chrome.runtime.getURL("icons/skip.svg");
-            skipButton.title = actionType === ActionType.Chapter ? chrome.i18n.getMessage("playChapter") 
+            skipButton.title = actionType === ActionType.Chapter ? chrome.i18n.getMessage("playChapter")
                 : chrome.i18n.getMessage("skipSegment");
             skipButton.addEventListener("click", () => skipSegment(actionType, UUID, skipButton));
             votingButtons.addEventListener("dblclick", () => skipSegment(actionType, UUID));
@@ -1022,7 +1033,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                 UUID: UUID
             });
         }
-        
+
         if (element) {
             const stopAnimation = AnimationUtils.applyLoadingAnimation(element, 0.3);
             stopAnimation();
@@ -1140,6 +1151,9 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
         switch (msg.message) {
             case "time":
                 displayDownloadedSponsorTimes(downloadedTimes, msg.time);
+                break;
+            case "infoUpdated":
+                infoFound(msg);
                 break;
         }
     }


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
This PR:
* Triggers a segment list refresh in the popup when content script loads new ones
* Changes the return value of `getYouTubeVideoID` on fail to `null` (simplifies type annotations & logic)
* Deduplicates and cleans up popup -> content script communication code in `popup.ts`
  * Removes the `sendMessage` function
  * Modifies `sendTabMessage` to use a provided callback, adds `sendTabMessageAsync` that returns a promise
  * Modifies any function that duplicated `sendTabMessage` code to call `sendTabMessage` or `sendTabMessageAsync`, making them async if needed and adding type annotations for response objects