### PR TITLE
Reduced execution time of hexToRgb function by 70%

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -363,6 +363,12 @@
   background-color: #00a205;
   transition: opacity 0.2s ease-out;
 }
+.switchBg.red {
+  opacity: 0;
+  position: absolute;
+  background-color: #fc0303;
+  transition: opacity 0.2s ease-out;
+}
 .switchDot {
   width: 15px;
   margin: 4px;
@@ -378,6 +384,9 @@
 }
 #toggleSwitch:checked ~ .switchBg.green {
   opacity: 1;
+}
+#toggleSwitch:checked ~ .switchBg.red {
+  opacity 1;
 }
 #toggleSwitch:checked ~ .switchBg.white {
   transition: opacity 0.2s step-end;

--- a/public/popup.html
+++ b/public/popup.html
@@ -81,7 +81,7 @@
             <input type="checkbox" style="display: none" id="toggleSwitch" checked>
             <span class="switchBg shadow"></span>
             <span class="switchBg white"></span>
-            <span class="switchBg green"></span>
+            <span class="switchBg red"></span>
             <span class="switchDot"></span>
           </span>
           <span id="disableSkipping">__MSG_disableSkipping__</span>

--- a/src/utils/genericUtils.ts
+++ b/src/utils/genericUtils.ts
@@ -92,20 +92,18 @@ function getLuminance(color: string): number {
     return Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b));
 }
 
-/* From https://stackoverflow.com/a/5624139 */
-function hexToRgb(hex: string): {r: number; g: number; b: number} {
-    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
-    const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
-      return r + r + g + g + b + b;
-    });
-  
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result ? {
-      r: parseInt(result[1], 16),
-      g: parseInt(result[2], 16),
-      b: parseInt(result[3], 16)
-    } : null;
+/* Converts hex color to rgb color */
+const hexChars = "0123456789abcdef";
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  if (hex.length == 4)
+    hex = "#" + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+  return /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+    ? {
+        r: hexChars.indexOf(hex[1]) * 16 + hexChars.indexOf(hex[2]),
+        g: hexChars.indexOf(hex[3]) * 16 + hexChars.indexOf(hex[4]),
+        b: hexChars.indexOf(hex[5]) * 16 + hexChars.indexOf(hex[6]),
+      }
+    : null;
 }
 
 /**


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

***

Because the "hexToRgb" function used unnecessary regex, I optimized it.