### PR TITLE
Use publicID instead of privateID for /userInfo calls

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -532,7 +532,7 @@ function activatePrivateTextChange(element: HTMLElement) {
         case "userID":
             if (Config.config[option]) {
                 utils.asyncRequestToServer("GET", "/api/userInfo", {
-                    userID: Config.config[option],
+                    publicUserID: utils.getHash(Config.config[option]),
                     values: ["warnings", "banned"]
                 }).then((result) => {
                     const userInfo = JSON.parse(result.responseText);

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -281,7 +281,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
     if (!Config.config.payments.freeAccess && !noRefreshFetchingChaptersAllowed()) values.push("freeChaptersAccess");
 
     utils.asyncRequestToServer("GET", "/api/userInfo", {
-        userID: Config.config.userID,
+        publicUserID: await utils.getHash(Config.config.userID),
         values
     }).then((res) => {
         if (res.status === 200) {
@@ -461,7 +461,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
                 } else {
                     PageElements.videoFound.innerHTML = chrome.i18n.getMessage("segmentsStillLoading");
                 }
-                
+
                 PageElements.issueReporterImportExport.classList.remove("hidden");
             }
         }

--- a/src/utils/licenseKey.ts
+++ b/src/utils/licenseKey.ts
@@ -15,7 +15,7 @@ export async function checkLicenseKey(licenseKey: string): Promise<boolean> {
             Config.config.showChapterInfoMessage = false;
             Config.config.payments.lastCheck = Date.now();
             Config.forceSyncUpdate("payments");
-            
+
             return true;
         }
     } catch (e) { } //eslint-disable-line no-empty
@@ -43,7 +43,7 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
             return licensePromise;
         }
     }
-    
+
     if (Config.config.payments.chaptersAllowed) return true;
 
     if (Config.config.payments.lastCheck === 0 && Date.now() - Config.config.payments.lastFreeCheck > 2 * 24 * 60 * 60 * 1000) {
@@ -53,7 +53,7 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
         // Check for free access if no license key, and it is the first time
         const result = await utils.asyncRequestToServer("GET", "/api/userInfo", {
             value: "freeChaptersAccess",
-            userID: Config.config.userID
+            publicUserID: await utils.getHash(Config.config.userID)
         });
 
         try {
@@ -66,7 +66,7 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
                     Config.config.payments.chaptersAllowed = true;
                     Config.config.showChapterInfoMessage = false;
                     Config.forceSyncUpdate("payments");
-    
+
                     return true;
                 }
             }

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -13,7 +13,7 @@ export interface ChatConfig {
 
 export async function openWarningDialog(contentContainer: ContentContainer): Promise<void> {
     const userInfo = await utils.asyncRequestToServer("GET", "/api/userInfo", {
-        userID: Config.config.userID,
+        publicUserID: await utils.getHash(Config.config.userID),
         values: ["warningReason"]
     });
 


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
This should reduce the load on the server a bit, as it will no longer have to compute the publicID for each sponsorblock user. 
This also reduces the list of actions that leak the privateID to the server.
