### PR TITLE
Added fallback server option

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,9 @@
 {
     "serverAddress": "https://sponsor.ajay.app",
     "testingServerAddress": "https://sponsor.ajay.app/test",
+    "fallbackServerAddress": "",
     "serverAddressComment": "This specifies the default SponsorBlock server to connect to",
+    "fallbackAddressComment": "This specifies the server SponsorBlock will attempt to connect to if the primary one fails.",
     "categoryList": ["sponsor", "selfpromo", "exclusive_access", "interaction", "poi_highlight", "intro", "outro", "preview", "filler", "chapter", "music_offtopic"],
     "categorySupport": {
         "sponsor": ["skip", "mute", "full"],

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -505,6 +505,12 @@
     "customServerAddressDescription": {
         "message": "The address SponsorBlock uses to make calls to the server.\nUnless you have your own server instance, this should not be changed."
     },
+    "fallbackServerAddress": {
+        "message": "SponsorBlock Fallback Server Address"
+    },
+    "fallbackServerAddressDescription": {
+        "message": "The address SponsorBlock uses to make calls to the server if the main server is down."
+    },
     "save": {
         "message": "Save"
     },

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -554,6 +554,26 @@
 						</div>
 					</div>
 				</div>
+				
+				<div data-type="text-change" data-sync="fallbackServerAddress" data-dependent-on="testingServer" data-dependent-on-inverted="true">
+					<label class="optionLabel inline">
+						<span class="optionLabel">__MSG_fallbackServerAddress__:</span>
+	
+						<input class="option-text-box" type="text" style="margin-right:10px">
+					</label>
+
+					<div class="small-description">__MSG_fallbackServerAddressDescription__</div>
+	
+					<div class="next-line">
+						<div class="option-button text-change-set inline">
+							__MSG_save__
+						</div>
+		
+						<div class="option-button text-change-reset inline">
+							__MSG_reset__
+						</div>
+					</div>
+				</div>
 
 			</div>
 

--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -696,11 +696,10 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
         this.saveEditTimes();
     }
 
-    async fetchSuggestions(description: string): Promise<void> {
+    async fetchSuggestions(description: string, fallbackServer = false): Promise<void> {
         if (this.props.contentContainer().channelIDInfo.status !== ChannelIDStatus.Found) return;
-
         this.fetchingSuggestions = true;
-        const result = await utils.asyncRequestToServer("GET", "/api/chapterNames", {
+        const result = await utils.asyncRequestToServer("GET", "/api/chapterNames", fallbackServer, {
             description,
             channelID: this.props.contentContainer().channelIDInfo.id
         });
@@ -713,7 +712,11 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                         label: n.description
                     }))
                 });
-            } catch (e) {} //eslint-disable-line no-empty
+            } catch (e) {
+                if (!fallbackServer) {
+                    this.fetchSuggestions(description, true);
+                }
+            } 
         }
 
         this.fetchingSuggestions = false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ interface SBConfig {
     invidiousInstances: string[];
     supportInvidious: boolean;
     serverAddress: string;
+    fallbackServerAddress: string;
     minDuration: number;
     skipNoticeDuration: number;
     audioNotificationOnSkip: boolean;
@@ -181,6 +182,7 @@ const Config: SBObject = {
         invidiousInstances: ["invidious.snopyta.org"], // leave as default
         supportInvidious: false,
         serverAddress: CompileConfig.serverAddress,
+        fallbackServerAddress: CompileConfig.fallbackServerAddress,
         minDuration: 0,
         skipNoticeDuration: 4,
         audioNotificationOnSkip: false,

--- a/src/options.ts
+++ b/src/options.ts
@@ -175,7 +175,8 @@ async function init() {
                 textChangeSetButton.addEventListener("click", async () => {
                     // See if anything extra must be done
                     switch (option) {
-                        case "serverAddress": {
+                        case "serverAddress":
+                        case "fallbackServerAddress": {
                             const result = validateServerAddress(textChangeInput.value);
 
                             if (result !== null) {
@@ -531,8 +532,8 @@ function activatePrivateTextChange(element: HTMLElement) {
     switch (option) {
         case "userID":
             if (Config.config[option]) {
-                utils.asyncRequestToServer("GET", "/api/userInfo", {
-                    publicUserID: utils.getHash(Config.config[option]),
+                utils.asyncRequestToServer("GET", "/api/userInfo", false, {
+                    userID: Config.config[option],
                     values: ["warnings", "banned"]
                 }).then((result) => {
                     const userInfo = JSON.parse(result.responseText);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -319,7 +319,6 @@ export default class Utils {
                 return selection;
             }
         }
-        return { name: "None", option: 0} as CategorySelection;
     }
 
     /**
@@ -365,11 +364,17 @@ export default class Utils {
      * 
      * @param type The request type. "GET", "POST", etc.
      * @param address The address to add to the SponsorBlock server address
+     * @param fallback Use the fallback server URL if true.
      * @param callback 
      */    
-    async asyncRequestToServer(type: string, address: string, data = {}): Promise<FetchResponse> {
-        const serverAddress = Config.config.testingServer ? CompileConfig.testingServerAddress : Config.config.serverAddress;
-
+    async asyncRequestToServer(type: string, address: string, fallback = false, data = {}): Promise<FetchResponse> {
+        let serverAddress = Config.config.serverAddress;
+        if (Config.config.testingServer){
+            serverAddress = CompileConfig.testingServerAddress;
+        } else if (fallback && Config.config.fallbackServerAddress) {
+            serverAddress = Config.config.fallbackServerAddress;
+        }        
+        
         return await (this.asyncRequestToCustomServer(type, serverAddress + address, data));
     }
 

--- a/src/utils/licenseKey.ts
+++ b/src/utils/licenseKey.ts
@@ -5,7 +5,7 @@ import * as CompileConfig from "../../config.json";
 const utils = new Utils();
 
 export async function checkLicenseKey(licenseKey: string): Promise<boolean> {
-    const result = await utils.asyncRequestToServer("GET", "/api/verifyToken", {
+    const result = await utils.asyncRequestToServer("GET", "/api/verifyToken", false,{
         licenseKey
     });
 
@@ -15,7 +15,7 @@ export async function checkLicenseKey(licenseKey: string): Promise<boolean> {
             Config.config.showChapterInfoMessage = false;
             Config.config.payments.lastCheck = Date.now();
             Config.forceSyncUpdate("payments");
-
+            
             return true;
         }
     } catch (e) { } //eslint-disable-line no-empty
@@ -43,7 +43,7 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
             return licensePromise;
         }
     }
-
+    
     if (Config.config.payments.chaptersAllowed) return true;
 
     if (Config.config.payments.lastCheck === 0 && Date.now() - Config.config.payments.lastFreeCheck > 2 * 24 * 60 * 60 * 1000) {
@@ -51,9 +51,9 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
         Config.forceSyncUpdate("payments");
 
         // Check for free access if no license key, and it is the first time
-        const result = await utils.asyncRequestToServer("GET", "/api/userInfo", {
+        const result = await utils.asyncRequestToServer("GET", "/api/userInfo", false,{
             value: "freeChaptersAccess",
-            publicUserID: await utils.getHash(Config.config.userID)
+            userID: Config.config.userID
         });
 
         try {
@@ -66,7 +66,7 @@ export async function fetchingChaptersAllowed(): Promise<boolean> {
                     Config.config.payments.chaptersAllowed = true;
                     Config.config.showChapterInfoMessage = false;
                     Config.forceSyncUpdate("payments");
-
+    
                     return true;
                 }
             }

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -12,8 +12,8 @@ export interface ChatConfig {
 }
 
 export async function openWarningDialog(contentContainer: ContentContainer): Promise<void> {
-    const userInfo = await utils.asyncRequestToServer("GET", "/api/userInfo", {
-        publicUserID: await utils.getHash(Config.config.userID),
+    const userInfo = await utils.asyncRequestToServer("GET", "/api/userInfo", false, {
+        userID: Config.config.userID,
         values: ["warningReason"]
     });
 
@@ -42,7 +42,7 @@ export async function openWarningDialog(contentContainer: ContentContainer): Pro
                 {
                     name: chrome.i18n.getMessage("warningConfirmButton"),
                     listener: async () => {
-                        const result = await utils.asyncRequestToServer("POST", "/api/warnUser", {
+                        const result = await utils.asyncRequestToServer("POST", "/api/warnUser", false, {
                             userID: Config.config.userID,
                             enabled: false
                         });


### PR DESCRIPTION
As the main server seems to be having some issues, I've added an option to use a fallback server when the main one fails. 

This defaults to "" (`undefined`) in the config, with users being able to set the URL below the standard URL option in options. 

If you've got `testingServer` set, this is overridden, and the form is removed from the options. 

How it works: 

Upon requesting sponsors, if the main server fails, we call `retryFetch` to try again. As we keep note of how many times we retry, we use the fallback server on every even retry, so it flips back and forth. 

The delay between retries has also been adjusted. 404 is the same, but if we've failed 2 or less times, we retry instantly, before going back to the previous delay setting.

As most users are only concerned about fetching sponsors, we don't use the fallback server for requests regarding submitting data.

We also only use the fallback server on `asyncRequestToServer()` calls, as nothing using the synchronous method would benefit.

As mentioned in issues #1570 and #1562 

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

***
