### PR TITLE
Typo "ait été" --> "a été"

### DIFF
--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -262,7 +262,7 @@
         "message": "Afficher la notification"
     },
     "showSkipNotice": {
-        "message": "Notifier après qu'un segment ait été sauté"
+        "message": "Notifier après qu'un segment a été sauté"
     },
     "showCategoryGuidelines": {
         "message": "Affiche l'aide de la catégorie"


### PR DESCRIPTION
In French, "après que" uses indicative tense.

- [ ] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
