### PR TITLE
Fix the incorrectVideoCheck() error showing the same videoID as recorded & actual

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -765,12 +765,13 @@ function inMuteSegment(currentTime: number, includeOverlap: boolean): boolean {
  */
 function incorrectVideoCheck(videoID?: string, sponsorTime?: SponsorTime): boolean {
     const currentVideoID = getYouTubeVideoID();
-    if (currentVideoID !== (videoID || getVideoID()) || (sponsorTime
+    const recordedVideoID = videoID || getVideoID();
+    if (currentVideoID !== recordedVideoID || (sponsorTime
             && (!sponsorTimes || !sponsorTimes?.some((time) => time.segment === sponsorTime.segment))
             && !sponsorTimesSubmitting.some((time) => time.segment === sponsorTime.segment))) {
         // Something has really gone wrong
         console.error("[SponsorBlock] The videoID recorded when trying to skip is different than what it should be.");
-        console.error("[SponsorBlock] VideoID recorded: " + getVideoID() + ". Actual VideoID: " + currentVideoID);
+        console.error("[SponsorBlock] VideoID recorded: " + recordedVideoID + ". Actual VideoID: " + currentVideoID);
 
         // Video ID change occured
         checkVideoIDChange();


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
This seems to happen if incorrectVideoCheck triggers while called from skippingFunction.