### PR TITLE
Set min width of previewbar segments to 1px

### DIFF
--- a/public/content.css
+++ b/public/content.css
@@ -45,6 +45,7 @@ div:hover > #previewbar.sbNotInvidious {
 .previewbar {
 	display: inline-block;
 	height: 100%;
+	min-width: 1px;
 }
 
 .previewbar.requiredSegment {
@@ -250,7 +251,7 @@ div:hover > .sponsorBlockChapterBar {
 }
 
 .exportCopiedNotice .sponsorSkipNoticeTableContainer {
-	background-color: transparent; 
+	background-color: transparent;
 }
 
 .sponsorSkipNotice {


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
This fixes short segments on long videos not appearing at all in small embeds
[Issue reported on discord](https://discord.com/channels/603643120093233162/603643256714297374/1104742118519488643)