### PR TITLE
Remove leaderboards button

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -190,7 +190,6 @@
       <footer id="sbFooter">
         <a id="helpButton">__MSG_help__</a>
         <a href="https://sponsor.ajay.app" target="_blank" rel="noopener">__MSG_website__</a>
-        <a href="https://sponsor.ajay.app/stats" target="_blank" rel="noopener">__MSG_viewLeaderboard__</a>
         <br />
         <a href="https://github.com/ajayyy/SponsorBlock" target="_blank" rel="noopener">GitHub</a>
         <a href="https://discord.gg/SponsorBlock" target="_blank" rel="noopener">Discord</a>


### PR DESCRIPTION
- [X] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

Removes button that leads to now defunct stats page from extension popup menu.
