### PR TITLE
Fix duration time to consider playback rate

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -843,8 +843,8 @@ function setupVideoListeners() {
         const rateChangeListener = () => {
             updateVirtualTime();
             clearWaitingTime();
-
             startSponsorSchedule();
+            updatePreviewBar();
         };
         getVideo().addEventListener('ratechange', rateChangeListener);
         // Used by videospeed extension (https://github.com/igrigorik/videospeed/pull/740)
@@ -2525,8 +2525,8 @@ function showTimeWithoutSkips(skippedDuration: number): void {
 
         display.appendChild(duration);
     }
-
-    const durationAfterSkips = getFormattedTime(getVideo()?.duration - skippedDuration);
+    
+    const durationAfterSkips = getFormattedTime((getVideo()?.duration - skippedDuration)/(getVideo()?.playbackRate ?? 1));
 
     duration.innerText = (durationAfterSkips == null || skippedDuration <= 0) ? "" : " (" + durationAfterSkips + ")";
 }


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

The duration of the video with skips now uses the playback rate to adjust the time.

Ex: 0:13 / 10:50 (9:16) @ 1x speed => 0:13 / 10:50 (4:38) @ 2x speed
