### PR TITLE
Add Start button on submit segment popup

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -128,6 +128,12 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                     style={timeDisplayStyle}
                     className="sponsorTimeDisplay">
 
+                        <span id={"startButton" + this.idSuffix}
+                            className="sponsorNowButton"
+                            onClick={() => this.setTimeTo(0, 0)}>
+                                {chrome.i18n.getMessage("bracketStart")}
+                        </span>
+
                         <span id={"nowButton0" + this.idSuffix}
                             className="sponsorNowButton"
                             onClick={() => this.setTimeToNow(0)}>


### PR DESCRIPTION
- [X] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
Potential implementation of #1835 - adding a Start button on the confirm segments pop up, to make it easier to submit intro segments.

Status quo:
![image](https://github.com/ajayyy/SponsorBlock/assets/12798735/47d49482-2441-4075-b8fa-c24f8b0dd7c3)

With Start button:
![image](https://github.com/ajayyy/SponsorBlock/assets/12798735/10d5dd2d-8af6-460c-bc52-b3841ce62edc)

