### PR TITLE
Overriding default webpack performance config to reduce warnings

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -185,6 +185,12 @@ module.exports = env => {
                 stream: env.stream
             }),
             new configDiffPlugin()
-        ]
+        ],
+        performance: {
+            hints: false,
+            maxEntrypointSize: 512000,
+            maxAssetSize: 512000
+        }
+
     };
 };


### PR DESCRIPTION
- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
Previously webpack compiled with 3 warnings:

<img width="540" alt="image" src="https://github.com/ajayyy/SponsorBlock/assets/3665694/c6cd8805-8ee9-44a1-b6f7-b5af7c9f8899">


Current build on this PR:

<img width="247" alt="image" src="https://github.com/ajayyy/SponsorBlock/assets/3665694/d867d097-6f33-4155-a015-d375c021bb56">
