### PR TITLE
Add WebExt Lint as CI job

### DIFF
--- a/.github/workflows/.github/workflows/webext-lint.yml
+++ b/.github/workflows/.github/workflows/webext-lint.yml
@@ -1,0 +1,23 @@
+name: Web-Ext lint
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "web-ext lint"
+        uses: kewisch/action-web-ext@v1
+        with:
+          cmd: lint
+          source: src
+          channel: listed


### PR DESCRIPTION
Inspired by https://github.com/rugk/awesome-emoji-picker/blob/main/.github/workflows/webext-lint.yml

As far as I see you don't run that anywhere else, so may this be a good idea?

Same as https://github.com/ajayyy/DeArrow/pull/187

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
