### PR TITLE
[Fix] Stop Refresh Animation on Popup When Triggered on Non-YouTube Pages

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -258,7 +258,12 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
             break;
         case "refreshSegments":
             // update video on refresh if videoID invalid
-            if (!getVideoID()) checkVideoIDChange();
+            if (!getVideoID()) {
+                checkVideoIDChange().then(() => {
+                    // if still no video ID found, return an empty info to the popup
+                    if (!getVideoID()) chrome.runtime.sendMessage({ message: "infoUpdated" });
+                });
+            }
             // fetch segments
             sponsorsLookup(false);
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -465,8 +465,8 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             return;
         }
 
-        //if request is undefined, then the page currently being browsed is not YouTube
-        if (request != undefined) {
+        // if request has no field other than message, then the page currently being browsed is not YouTube
+        if (request.found != undefined) {
             //remove loading text
             PageElements.mainControls.style.display = "block";
             if (request.onMobileYouTube) PageElements.mainControls.classList.add("hidden");
@@ -490,6 +490,8 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
 
                 PageElements.issueReporterImportExport.classList.remove("hidden");
             }
+        } else {
+            displayNoVideo();
         }
 
         //see if whitelist button should be swapped


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

***

The refresh animation on the popup page never ends if it is clicked on a non-video page. My fix is to send an empty message to popup, and stop the animation.

BTW: Some message handlers are using `response != undefined` to test if there is any content in the message, but a message will always have a field: `"message": "message_name"`, so the test will always pass. I found this one in `vote()` handler, maybe there are more on other pages. We should probably test if other fields exist, or exclude `message` using a util function. 

https://github.com/ajayyy/SponsorBlock/blob/742eb7ef57e1de436553eed20c45bf9542a86369/src/popup.ts#L900-L901

The printed empty message. It's not "empty"
![image](https://github.com/ajayyy/SponsorBlock/assets/31091101/d20711fd-ca8a-475d-862f-5259871cdac2)