### PR TITLE
[Fix #1979] Stop Refresh Animation on Popup When Content Script is Not Injected

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -259,11 +259,11 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
         case "refreshSegments":
             // update video on refresh if videoID invalid
             if (!getVideoID()) {
-                checkVideoIDChange().then(() => {
-                    // if still no video ID found, return an empty info to the popup
-                    if (!getVideoID()) chrome.runtime.sendMessage({ message: "infoUpdated" });
-                });
+                checkVideoIDChange();
             }
+            // if popup rescieves no response, or the videoID is invalid,
+            // it will assume the page is not a video page and stop the refresh animation
+            sendResponse({ hasVideo: getVideoID() != null });
             // fetch segments
             sponsorsLookup(false);
 

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -103,7 +103,8 @@ export type MessageResponse =
     | IsChannelWhitelistedResponse
     | Record<string, never> // empty object response {}
     | VoteResponse
-    | ImportSegmentsResponse;
+    | ImportSegmentsResponse
+    | RefreshSegmentsResponse;
 
 export interface VoteResponse {
     successType: number;
@@ -113,6 +114,10 @@ export interface VoteResponse {
 
 interface ImportSegmentsResponse {
     importedSegments: SponsorTime[];
+}
+
+export interface RefreshSegmentsResponse {
+    hasVideo: boolean;
 }
 
 export interface TimeUpdateMessage {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -15,6 +15,7 @@ import {
     Message,
     MessageResponse,
     PopupMessage,
+    RefreshSegmentsResponse,
     SponsorStartResponse,
     VoteResponse,
 } from "./messageTypes";
@@ -982,9 +983,17 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
         stopLoadingAnimation = AnimationUtils.applyLoadingAnimation(PageElements.refreshSegmentsButton, 0.3);
     }
 
-    function refreshSegments() {
+    async function refreshSegments() {
         startLoadingAnimation();
-        sendTabMessage({ message: 'refreshSegments' });
+        const response = await sendTabMessageAsync({ message: 'refreshSegments' }) as RefreshSegmentsResponse;
+
+        if (response == null || !response.hasVideo) {
+            if (stopLoadingAnimation != null) {
+                stopLoadingAnimation();
+                stopLoadingAnimation = null;
+            }
+            displayNoVideo();
+        }
     }
 
     function skipSegment(actionType: ActionType, UUID: SegmentUUID, element?: HTMLElement): void {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -460,39 +460,35 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             stopLoadingAnimation = null;
         }
 
-        if (chrome.runtime.lastError) {
+        if (chrome.runtime.lastError || request == undefined || request.found == undefined) {
             //This page doesn't have the injected content script, or at least not yet
+            // Or if the request is empty, meaning the current page is not YouTube or a video page
             displayNoVideo();
             return;
         }
 
-        // if request has no field other than message, then the page currently being browsed is not YouTube
-        if (request.found != undefined) {
-            //remove loading text
-            PageElements.mainControls.style.display = "block";
-            if (request.onMobileYouTube) PageElements.mainControls.classList.add("hidden");
-            PageElements.whitelistButton.classList.remove("hidden");
-            PageElements.loadingIndicator.style.display = "none";
+        //remove loading text
+        PageElements.mainControls.style.display = "block";
+        if (request.onMobileYouTube) PageElements.mainControls.classList.add("hidden");
+        PageElements.whitelistButton.classList.remove("hidden");
+        PageElements.loadingIndicator.style.display = "none";
 
-            downloadedTimes = request.sponsorTimes ?? [];
-            displayDownloadedSponsorTimes(downloadedTimes, request.time);
-            if (request.found) {
-                PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsorFound");
-                PageElements.issueReporterImportExport.classList.remove("hidden");
-            } else if (request.status == 404 || request.status == 200) {
-                PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsor404");
-                PageElements.issueReporterImportExport.classList.remove("hidden");
-            } else {
-                if (request.status) {
-                    PageElements.videoFound.innerHTML = chrome.i18n.getMessage("connectionError") + request.status;
-                } else {
-                    PageElements.videoFound.innerHTML = chrome.i18n.getMessage("segmentsStillLoading");
-                }
-
-                PageElements.issueReporterImportExport.classList.remove("hidden");
-            }
+        downloadedTimes = request.sponsorTimes ?? [];
+        displayDownloadedSponsorTimes(downloadedTimes, request.time);
+        if (request.found) {
+            PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsorFound");
+            PageElements.issueReporterImportExport.classList.remove("hidden");
+        } else if (request.status == 404 || request.status == 200) {
+            PageElements.videoFound.innerHTML = chrome.i18n.getMessage("sponsor404");
+            PageElements.issueReporterImportExport.classList.remove("hidden");
         } else {
-            displayNoVideo();
+            if (request.status) {
+                PageElements.videoFound.innerHTML = chrome.i18n.getMessage("connectionError") + request.status;
+            } else {
+                PageElements.videoFound.innerHTML = chrome.i18n.getMessage("segmentsStillLoading");
+            }
+
+            PageElements.issueReporterImportExport.classList.remove("hidden");
         }
 
         //see if whitelist button should be swapped


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

***

This is a follow up of PR #1979. My last fix relied on the content script sending back a message to the popup. But I overlooked the case where on non-YouTube sites, the content script is not injected at all. So I switched to use the message `sendResponse` callback to inform the popup. If the refresh message receives no response, it assumes that the current page is not YouTube and stops the animation, which I think is cleaner and less convoluted.

I also refactored `infoFound` in Popup.js. It now has one less indentation and a early return.