### PR TITLE
Use React fragments to avoid wrapping elements

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -156,7 +156,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                         </input>
 
                         {this.state.selectedActionType !== ActionType.Poi ? (
-                            <span>
+                            <>
                                 <span>
                                     {" " + chrome.i18n.getMessage("to") + " "}
                                 </span>
@@ -183,7 +183,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                                     onClick={() => this.setTimeToEnd()}>
                                         {chrome.i18n.getMessage("bracketEnd")}
                                 </span>
-                            </span>
+                            </>
                         ): ""}
                 </div>
             );


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

***

Currently, the component renders another `<span>` and put all the conditional elements inside, which makes the same-level elements reside in separate wrapping spans. Using React fragments (`<></>`) as a wrapping placeholder can solve this. And it allowed for better layout controls, such as using flow or grid.