### PR TITLE
Fix refreshing

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -11,6 +11,9 @@
             "https://*.youtube.com/*",
             "https://www.youtube-nocookie.com/embed/*"
         ],
+        "exclude_matches": [
+            "https://accounts.youtube.com/RotateCookiesPage*"
+        ],
         "all_frames": true,
         "js": [
             "./js/content.js"

--- a/src/content.ts
+++ b/src/content.ts
@@ -264,7 +264,9 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
             // it will assume the page is not a video page and stop the refresh animation
             sendResponse({ hasVideo: getVideoID() != null });
             // fetch segments
-            sponsorsLookup(false);
+            if (getVideoID()) {
+                sponsorsLookup(false);
+            }
 
             break;
         case "unskip":
@@ -1115,7 +1117,12 @@ async function sponsorsLookup(keepOldSubmissions = true) {
     const hashParams = getHashParams();
     if (hashParams.requiredSegment) extraRequestData.requiredSegment = hashParams.requiredSegment;
 
-    const hashPrefix = (await getHash(getVideoID(), 1)).slice(0, 4) as VideoID & HashedValue;
+    const videoID = getVideoID()
+    if (!videoID) {
+        console.error("[SponsorBlock] Attempted to fetch segments with a null/undefined videoID.");
+        return;
+    }
+    const hashPrefix = (await getHash(videoID, 1)).slice(0, 4) as VideoID & HashedValue;
     const response = await asyncRequestToServer('GET', "/api/skipSegments/" + hashPrefix, {
         categories,
         actionTypes: getEnabledActionTypes(),


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
This PR fixes an issue that was reported on discord, where the after pressing the refresh button segments would sometimes show up and sometimes the segment list would be empty.
[Latest report/investigation thread in #concerns on discord](https://discord.com/channels/603643120093233162/603643256714297374/1250559680351174838)

This appears to be caused by a hidden iframe which holds the page `https://accounts.youtube.com/RotateCookiesPage`, where the content script would be injected in addition to the root page.
This iframe is only present when logged in, and as such this issue does not appear when logged out.
Both the root and iframe content scripts would subscribe to messages from the popup page, which caused a sort of race condition when the refresh button was pressed.
The iframe page's videoID would always be `null`. Due to a possible oversight, the `sponsorsLookup` function did not check whether videoID was valid, and ended up always trying to fetch the `7423` hashblock, which corresponds to the string `null`.
Depending on which content script got the data first, the segments list in the popup would appear or disappear.

This PR mitigates this issue by:
* Excluding the `https://accounts.youtube.com/RotateCookiesPage*` URL from content script's injection targets by adding an entry into the manifest
* Adding null checks before the `sponsorsLookup` function is called
* Adding a null check into the `sponsorsLookup` function which prints an error to the console if called with a null videoID and returns early