### PR TITLE
Set backround script persistent to true for FireFox

### DIFF
--- a/manifest/firefox-manifest-extra.json
+++ b/manifest/firefox-manifest-extra.json
@@ -9,7 +9,7 @@
     }
   },
   "background": {
-    "persistent": false
+    "persistent": true
   },
   "browser_action": {
     "default_area": "navbar"


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***  
Stopgap fix for #1993 ["Video rotates from landscape to portrait Firefox Android"](https://github.com/ajayyy/SponsorBlock/issues/1993) with info and reasoning for this PR visable [here](https://github.com/ajayyy/SponsorBlock/issues/1993#issuecomment-2544029970):  

> > I believe the cause may be rooted in the background script being unloaded/removed, am currently testing with this [change](https://github.com/Wolfdv1/SponsorBlock-ff-fenix/commit/c8c4a6ca709891445e92458208cbd207c10d376c) to help confirm, which just sets the background script to be persistent.
> > Not ideal in the long term, however for now running [this](https://github.com/Wolfdv1/SponsorBlock-ff-fenix/actions/runs/12331186928) artifact from local install on FF nightly and having had around 4hrs of videos played- the rotation issue is gone.
> 
> Correction: Not when it is removed, only when the runtime reloads it back in.
> 
> So when the background script (or 'event page' as it is referred to when persistence is false) is not running and an event (interacting with video controls, segment updates, or a segment skip etc) is called that requires a message to be handled and the script becomes active - this bug occurs.
> 
> Have experimented with narrowing down what about loafing the script causes this but haven't had much success- the event listeners that make up most of the script seem to all follow mdn web docs recommendations and practice, could be elsewhere in the utils or even node/react -Dom etc but I am not familiar enough with these to locate it. Could even be a FF issue more generally.
> 
> My reccomendation would be to simply set persistence to true as this mitigates the issue until more info, or there is an update for https://bugzilla.mozilla.org/show_bug.cgi?id=1927557. I would've liked to have found a fix that maintains inpersistance and therefore is manifest V3 ready, but since the script spends most of its time loaded on YT anyway and for Firefox Android there are no plans to remove V2 support I think I'll open a PR for this. At least then we can not have to use workarounds such as old vulnerable versions of FF, local addons, using autorotate etc.

