### PR TITLE
Finalized implementing channel specific settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/wicg-mediasession": "^1.1.4",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "@typescript-eslint/parser": "^5.54.1",
-        "chromedriver": "^110.0.0",
+        "chromedriver": "^134.0.0",
         "concurrently": "^7.6.0",
         "copy-webpack-plugin": "^11.0.0",
         "eslint": "^8.35.0",
@@ -1843,6 +1843,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
@@ -2180,13 +2187,11 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2357,13 +2362,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2398,13 +2401,11 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3250,6 +3251,26 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ast-types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
@@ -3495,6 +3516,16 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
@@ -4047,25 +4078,26 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-110.0.0.tgz",
-      "integrity": "sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==",
+      "version": "134.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-134.0.0.tgz",
+      "integrity": "sha512-zdvVh5WzoSsN6U4cUxTQEPTJrC4c9O7Kfc50RWPztQKb4DV84UHvVuLyKfCHHRPehWSA2AQU6rxni5FpBfkmGw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "@testim/chrome-version": "^1.1.4",
+        "axios": "^1.7.4",
+        "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.1",
+        "proxy-agent": "^6.4.0",
         "proxy-from-env": "^1.1.0",
-        "tcp-port-used": "^1.0.1"
+        "tcp-port-used": "^1.0.2"
       },
       "bin": {
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -4203,10 +4235,11 @@
       }
     },
     "node_modules/compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
-      "dev": true
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4490,10 +4523,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4912,6 +4946,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
@@ -5276,15 +5325,15 @@
       }
     },
     "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "esutils": "^2.0.2"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6337,13 +6386,11 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6570,6 +6617,56 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-uri/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -7103,6 +7200,27 @@
       "funding": {
         "url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ip-regex": {
       "version": "4.3.0",
@@ -9071,13 +9189,11 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9436,6 +9552,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.1.tgz",
@@ -9648,19 +9771,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/lie": {
       "version": "3.3.0",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
@@ -9758,18 +9868,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9857,12 +9955,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -10084,6 +10183,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
@@ -10157,13 +10266,11 @@
       }
     },
     "node_modules/node-notifier/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10382,23 +10489,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/os-locale": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
@@ -10535,6 +10625,103 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
@@ -10560,13 +10747,11 @@
       "dev": true
     },
     "node_modules/package-json/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10790,15 +10975,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -10892,6 +11068,99 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -11555,9 +11824,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -11578,13 +11849,11 @@
       }
     },
     "node_modules/semver-diff/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11699,6 +11968,82 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "3.8.1",
@@ -12285,9 +12630,11 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.2",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12373,13 +12720,11 @@
       }
     },
     "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12460,18 +12805,6 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-detect": {
@@ -12666,13 +12999,11 @@
       }
     },
     "node_modules/update-notifier/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13364,15 +13695,6 @@
       "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
       "dev": true
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -13569,12 +13891,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -14990,6 +15306,12 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
@@ -15303,13 +15625,10 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -15400,13 +15719,10 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -15427,13 +15743,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -16085,6 +16398,23 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
+        }
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
@@ -16262,6 +16592,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true
     },
     "big-integer": {
@@ -16627,18 +16963,18 @@
       }
     },
     "chromedriver": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-110.0.0.tgz",
-      "integrity": "sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==",
+      "version": "134.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-134.0.0.tgz",
+      "integrity": "sha512-zdvVh5WzoSsN6U4cUxTQEPTJrC4c9O7Kfc50RWPztQKb4DV84UHvVuLyKfCHHRPehWSA2AQU6rxni5FpBfkmGw==",
       "dev": true,
       "requires": {
-        "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "@testim/chrome-version": "^1.1.4",
+        "axios": "^1.7.4",
+        "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.1",
+        "proxy-agent": "^6.4.0",
         "proxy-from-env": "^1.1.0",
-        "tcp-port-used": "^1.0.1"
+        "tcp-port-used": "^1.0.2"
       }
     },
     "ci-info": {
@@ -16748,9 +17084,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true
     },
     "concat-map": {
@@ -16968,9 +17304,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -17251,6 +17587,17 @@
         "object-keys": "^1.1.1"
       }
     },
+    "degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "requires": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
@@ -17518,15 +17865,14 @@
       "dev": true
     },
     "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
         "source-map": "~0.6.1"
       },
       "dependencies": {
@@ -18262,13 +18608,10 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -18431,6 +18774,40 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "dev": true,
+      "requires": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "data-uri-to-buffer": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+          "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
       }
     },
     "glob": {
@@ -18804,6 +19181,24 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
       "integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==",
       "dev": true
+    },
+    "ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+          "dev": true
+        }
+      }
     },
     "ip-regex": {
       "version": "4.3.0",
@@ -20227,13 +20622,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -20497,6 +20889,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.1.tgz",
@@ -20662,16 +21060,6 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
-    },
     "lie": {
       "version": "3.3.0",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
@@ -20756,15 +21144,6 @@
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -20834,12 +21213,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -21011,6 +21390,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true
+    },
     "node-abort-controller": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
@@ -21061,13 +21446,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -21219,20 +21601,6 @@
         "is-wsl": "^2.2.0"
       }
     },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      }
-    },
     "os-locale": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
@@ -21326,6 +21694,75 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "requires": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      }
+    },
     "package-json": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
@@ -21339,13 +21776,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -21524,12 +21958,6 @@
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true
-    },
     "pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -21607,6 +22035,71 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
+    },
+    "proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -22087,8 +22580,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "semver-diff": {
@@ -22101,13 +22595,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -22200,6 +22691,56 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
+    "socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dev": true,
+      "requires": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+          "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
     },
     "sonic-boom": {
       "version": "3.8.1",
@@ -22623,8 +23164,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.2",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
           "dev": true
         }
       }
@@ -22682,13 +23224,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -22734,15 +23273,6 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
-      }
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -22867,13 +23397,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
         }
       }
     },
@@ -23360,12 +23887,6 @@
       "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
       "dev": true
     },
-    "word-wrap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -23502,12 +24023,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/wicg-mediasession": "^1.1.4",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
-    "chromedriver": "^110.0.0",
+    "chromedriver": "^134.0.0",
     "concurrently": "^7.6.0",
     "copy-webpack-plugin": "^11.0.0",
     "eslint": "^8.35.0",

--- a/public/icons/deleteChannelSpecificSettings.svg
+++ b/public/icons/deleteChannelSpecificSettings.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 195 316">
+	<path d="M195 0V47H0V0H195m0 61V316H0V61H195M29 93V283H55V93H29m55 1V283h27V94H84m53-1V283h26V93H137Z" fill="#fff"/>
+</svg>

--- a/public/popup.css
+++ b/public/popup.css
@@ -301,24 +301,6 @@
 }
 
 /*
- * Whitelist add/remove icon
- */
-.SBWhitelistIcon > path {
-  fill: var(--sb-main-fg-color);
-}
-.SBWhitelistIcon.rotated {
-  transform: rotate(45deg);
-}
-@keyframes rotate {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/*
  * "Skipping is enabled" toggle
  */
 .toggleSwitchContainer {
@@ -407,17 +389,15 @@
 }
 
 /*
- * Notice that appears when whitelisting a channel, that recommends
- * enabling the "Force Channel Check Before Skipping" option
+ * Notice that appears when creating channel specific settings, that informs to
+ * enable the "Force Channel Check Before Skipping" option
  */
-#whitelistForceCheck,
 #channelSettingsForceCheck {
   background-color: #fff3cd;
   padding: 10px 15px;
   display: block;
   color: #664d03;
 }
-#whitelistForceCheck:hover,
 #channelSettingsForceCheck:hover {
   background-color: #f2e4b7;
 }

--- a/public/popup.css
+++ b/public/popup.css
@@ -372,17 +372,56 @@
   opacity: 0;
 }
 
+
+ /* "Channel Overrides are enabled" toggle
+ */
+#channelOverridesToggleSwitch:checked ~ .switchDot {
+  transform: translateX(27px);
+}
+#channelOverridesToggleSwitch:checked ~ .switchBg.green {
+  opacity: 1;
+}
+#channelOverridesToggleSwitch:checked ~ .switchBg.white {
+  transition: opacity 0.2s step-end;
+  opacity: 0;
+}
+
+#channelOverridesList {
+  margin: 16px;
+  margin-top: 0;
+  padding: 8px 12px;
+  text-align: left;
+  border-radius: 8px;
+  border: 2px solid var(--sb-grey-bg-color);
+}
+
+.popupCategory {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: right;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+select{
+  width: 100%;
+}
 /*
  * Notice that appears when whitelisting a channel, that recommends
  * enabling the "Force Channel Check Before Skipping" option
  */
-#whitelistForceCheck {
+#whitelistForceCheck,
+#channelSettingsForceCheck {
   background-color: #fff3cd;
   padding: 10px 15px;
   display: block;
   color: #664d03;
 }
-#whitelistForceCheck:hover {
+#whitelistForceCheck:hover,
+#channelSettingsForceCheck:hover {
   background-color: #f2e4b7;
 }
 

--- a/public/popup.css
+++ b/public/popup.css
@@ -375,18 +375,18 @@
 
  /* "Channel Overrides are enabled" toggle
  */
-#channelOverridesToggleSwitch:checked ~ .switchDot {
+#channelSpecificSettingsToggleSwitch:checked ~ .switchDot {
   transform: translateX(27px);
 }
-#channelOverridesToggleSwitch:checked ~ .switchBg.green {
+#channelSpecificSettingsToggleSwitch:checked ~ .switchBg.green {
   opacity: 1;
 }
-#channelOverridesToggleSwitch:checked ~ .switchBg.white {
+#channelSpecificSettingsToggleSwitch:checked ~ .switchBg.white {
   transition: opacity 0.2s step-end;
   opacity: 0;
 }
 
-#channelOverridesList {
+#channelSpecificSettingsList {
   margin: 16px;
   margin-top: 0;
   padding: 8px 12px;
@@ -406,9 +406,6 @@
   font-size: 14px;
 }
 
-select{
-  width: 100%;
-}
 /*
  * Notice that appears when whitelisting a channel, that recommends
  * enabling the "Force Channel Check Before Skipping" option

--- a/public/popup.html
+++ b/public/popup.html
@@ -67,14 +67,6 @@
 
       <!-- Toggle Box -->
       <div class="sbControlsMenu">
-        <label id="whitelistButton" for="whitelistToggle" class="hidden sbControlsMenu-item" title="__MSG_channelSettingsPopup__">
-          <input type="checkbox" style="display: none" id="whitelistToggle">
-          <svg viewBox="0 0 24 24" width="23" height="23" class="SBWhitelistIcon sbControlsMenu-itemIcon">
-            <path d="M24 10H14V0h-4v10H0v4h10v10h4V14h10z" />
-          </svg>
-          <span id="whitelistChannel">__MSG_whitelistChannel__</span>
-          <span id="unwhitelistChannel" style="display: none">__MSG_removeFromWhitelist__</span>
-        </label>
         <!--github: mbledkowski/toggle-switch-->
         <label id="disableExtension" for="toggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
           <span class="toggleSwitchContainer-switch">
@@ -92,10 +84,6 @@
           __MSG_Options__
         </button>
       </div>
-
-      <a id="whitelistForceCheck" class="hidden">
-        __MSG_forceChannelCheckPopup__
-      </a>
 
       <!-- Channel specific settings box -->
       <!--github: scaccoman/SponsorBlock-->

--- a/public/popup.html
+++ b/public/popup.html
@@ -97,6 +97,31 @@
         __MSG_forceChannelCheckPopup__
       </a>
 
+      <!-- Channel Overrides Box -->
+      <!--github: scaccoman/SponsorBlock-->
+      <div class="sbControlsMenu">
+        <label id="channelOverrides" for="channelOverridesToggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
+        <span class="toggleSwitchContainer-switch">
+          <input type="checkbox" style="display:none;" id="channelOverridesToggleSwitch" checked>
+          <span class="switchBg shadow"></span>
+          <span class="switchBg white"></span>
+          <span class="switchBg green"></span>
+          <span class="switchDot"></span>
+        </span>
+        <span id="disableChannelOverrides">__MSG_disableChannelOverrides__</span>
+        <span id="enableChannelOverrides" style="display: none">__MSG_enableChannelOverrides__</span>
+      </div>
+
+      <a id="channelSettingsForceCheck" class="hidden">
+        __MSG_forceChannelCheckRequired__
+      </a>
+
+      <!-- Channel Overrides Container -->
+      <div id="channelOverridesContainer" style="display: none">
+        <ul id="channelOverridesList">
+        </ul>
+      </div>
+
       <!-- Submit box -->
       <div id="mainControls" style="display: none">
         <h1 class="sbHeader">

--- a/public/popup.html
+++ b/public/popup.html
@@ -102,7 +102,7 @@
       <div class="sbControlsMenu">
         <label id="channelSpecificSettings" for="channelSpecificSettingsToggleSwitch" class="hidden toggleSwitchContainer sbControlsMenu-item">
         <span class="toggleSwitchContainer-switch">
-          <input type="checkbox" style="display:none;" id="channelSpecificSettingsToggleSwitch" checked>
+          <input type="checkbox" style="display:none;" id="channelSpecificSettingsToggleSwitch" checked="false">
           <span class="switchBg shadow"></span>
           <span class="switchBg white"></span>
           <span class="switchBg green"></span>
@@ -110,6 +110,11 @@
         </span>
         <span id="disableChannelSpecificSettings">__MSG_disableChannelSpecificSettings__</span>
         <span id="enableChannelSpecificSettings" style="display: none">__MSG_enableChannelSpecificSettings__</span>
+        </label>
+        <button id="channelSpecificSettingsDeleteButton" class = "hidden sbControlsMenu-item">
+          <img src="/icons/deleteChannelSpecificSettings.svg" alt="Delete settings icon" height="24" class="sbControlsMenu-itemIcon" />
+          __MSG_deleteChannelSpecificSettings__
+        </button>
       </div>
 
       <a id="channelSettingsForceCheck" class="hidden">

--- a/public/popup.html
+++ b/public/popup.html
@@ -97,28 +97,28 @@
         __MSG_forceChannelCheckPopup__
       </a>
 
-      <!-- Channel Overrides Box -->
+      <!-- Channel specific settings box -->
       <!--github: scaccoman/SponsorBlock-->
       <div class="sbControlsMenu">
-        <label id="channelOverrides" for="channelOverridesToggleSwitch" class="toggleSwitchContainer sbControlsMenu-item">
+        <label id="channelSpecificSettings" for="channelSpecificSettingsToggleSwitch" class="hidden toggleSwitchContainer sbControlsMenu-item">
         <span class="toggleSwitchContainer-switch">
-          <input type="checkbox" style="display:none;" id="channelOverridesToggleSwitch" checked>
+          <input type="checkbox" style="display:none;" id="channelSpecificSettingsToggleSwitch" checked>
           <span class="switchBg shadow"></span>
           <span class="switchBg white"></span>
           <span class="switchBg green"></span>
           <span class="switchDot"></span>
         </span>
-        <span id="disableChannelOverrides">__MSG_disableChannelOverrides__</span>
-        <span id="enableChannelOverrides" style="display: none">__MSG_enableChannelOverrides__</span>
+        <span id="disableChannelSpecificSettings">__MSG_disableChannelSpecificSettings__</span>
+        <span id="enableChannelSpecificSettings" style="display: none">__MSG_enableChannelSpecificSettings__</span>
       </div>
 
       <a id="channelSettingsForceCheck" class="hidden">
         __MSG_forceChannelCheckRequired__
       </a>
 
-      <!-- Channel Overrides Container -->
-      <div id="channelOverridesContainer" style="display: none">
-        <ul id="channelOverridesList">
+      <!-- Channel specific settings container -->
+      <div id="channelSpecificSettingsContainer" style="display: none">
+        <ul id="channelSpecificSettingsList">
         </ul>
       </div>
 

--- a/src/components/PopupCategorySkipOptionsComponent.tsx
+++ b/src/components/PopupCategorySkipOptionsComponent.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+
+import Config from "../config"
+import { Category, CategorySkipOption } from "../types";
+
+import { getCategorySuffix } from "../utils/categoryUtils";
+
+export interface PopupCategorySkipOptionsProps { 
+    category: Category;
+    channelID: string;
+    deleteButton: HTMLElement;
+}
+
+class PopupCategorySkipOptionsComponent extends React.Component<PopupCategorySkipOptionsProps> {
+    constructor(props: PopupCategorySkipOptionsProps) {
+        super(props);
+    }
+
+    render(): React.ReactElement {
+        let defaultOption = "global";
+        // Set the default option properly
+        if (Config.config.channelSpecificSettings?.[this.props.channelID]){
+            for (const categorySelection of Config.config.channelSpecificSettings[this.props.channelID].categorySelections) {
+                if (categorySelection.name === this.props.category) {
+                    switch (categorySelection.option) {
+                        case CategorySkipOption.ShowOverlay:
+                            defaultOption = "showOverlay";
+                            break;
+                        case CategorySkipOption.ManualSkip:
+                            defaultOption = "manualSkip";
+                            break;
+                        case CategorySkipOption.AutoSkip:
+                            defaultOption = "autoSkip";
+                            break;
+                        case CategorySkipOption.Disabled:
+                            defaultOption = "disable";
+                    }
+    
+                    break;
+                }
+            }
+        }
+
+        return (
+            <>
+                <span id={this.props.category + "OptionsRow"}
+                    className={"popupCategory"} >
+                    <span id={this.props.category + "OptionName"}
+                        className="categoryTableLabel">
+                            {chrome.i18n.getMessage("category_" + this.props.category)}
+                    </span>
+                    <select
+                        defaultValue={defaultOption}
+                        onChange={this.skipOptionSelected.bind(this)}>
+                            {this.getCategorySkipOptions()}
+                    </select>
+
+                </span>
+            </>
+        );
+    }
+
+    skipOptionSelected(event: React.ChangeEvent<HTMLSelectElement>): void {
+        if (!Config.config.channelSpecificSettings[this.props.channelID]) {
+            Config.config.channelSpecificSettings[this.props.channelID] = {
+                toggle : true,
+                categorySelections: []
+            };
+            this.props.deleteButton.classList.remove("hidden");
+        }
+        const channelSettings = Config.config.channelSpecificSettings[this.props.channelID];
+        let option: CategorySkipOption;
+
+        switch (event.target.value) {
+            case "global":
+                channelSettings.categorySelections = channelSettings.categorySelections.filter(
+                    categorySelection => categorySelection.name !== this.props.category);
+                Config.forceSyncUpdate("channelSpecificSettings");
+                return;
+            case "disable":
+                option = CategorySkipOption.Disabled;
+
+                break;
+            case "showOverlay":
+                option = CategorySkipOption.ShowOverlay;
+
+                break;
+            case "manualSkip":
+                option = CategorySkipOption.ManualSkip;
+
+                break;
+            case "autoSkip":
+                option = CategorySkipOption.AutoSkip;
+
+                if (this.props.category === "filler" && !Config.config.isVip) {
+                    if (!confirm(chrome.i18n.getMessage("FillerWarning"))) {
+                        event.target.value = "disable";
+                    }
+                }
+
+                break;
+        }
+
+        const existingSelection = channelSettings.categorySelections.find(selection => selection.name === this.props.category);
+        if (existingSelection) {
+            existingSelection.option = option;
+        } else {
+            channelSettings.categorySelections.push({
+                name: this.props.category,
+                option: option
+            });
+        }
+
+        Config.forceSyncUpdate("channelSpecificSettings");
+    }
+
+    getCategorySkipOptions(): JSX.Element[] {
+        const elements: JSX.Element[] = [];
+
+        let optionNames = ["global", "disable", "showOverlay", "manualSkip", "autoSkip"];
+        if (this.props.category === "chapter") optionNames = ["global", "disable", "showOverlay"]
+        else if (this.props.category === "exclusive_access") optionNames = ["global", "disable", "showOverlay"];
+
+        function optionToString(option: CategorySkipOption, category: Category) : string {
+            let optionName = "disable";
+            switch (option) {
+                case CategorySkipOption.ShowOverlay:
+                    optionName = "showOverlay";
+                    break;
+                case CategorySkipOption.ManualSkip:
+                    optionName = "manualSkip";
+                    break;
+                case CategorySkipOption.AutoSkip:
+                    optionName = "autoSkip";
+                    break;
+                default:
+                    return `(${chrome.i18n.getMessage(optionName)})`;
+            }
+            return `(${chrome.i18n.getMessage( optionName + getCategorySuffix(category))})`;
+        }
+
+        for (const optionName of optionNames) {
+            elements.push(
+                <option key={optionName} value={optionName}>
+                    {`${chrome.i18n.getMessage( (optionName !== "disable" && optionName !== "global") ? optionName + getCategorySuffix(this.props.category) 
+                                                                     : optionName)} ${optionName === "global" ? (optionToString(Config.config.categorySelections.find(selection => selection.name === this.props.category)?.option, this.props.category)) : ""}`}
+                </option>
+            );
+        }
+
+        return elements;
+    }
+}
+
+export default PopupCategorySkipOptionsComponent;

--- a/src/components/options/CategoryChooserComponent.tsx
+++ b/src/components/options/CategoryChooserComponent.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 
 import * as CompileConfig from "../../../config.json";
-import { Category, CategorySkipOption } from "../../types";
+import { Category } from "../../types";
 import CategorySkipOptionsComponent from "./CategorySkipOptionsComponent";
-import Config from "../config";
+import Config from "../../config";
 
 export interface CategoryChooserProps { 
 
 }
 
 export interface CategoryChooserState {
-    selectedChannel: string
+    selectedChannel: string;
 }
 
 class CategoryChooserComponent extends React.Component<CategoryChooserProps, CategoryChooserState> {

--- a/src/components/options/CategoryChooserComponent.tsx
+++ b/src/components/options/CategoryChooserComponent.tsx
@@ -3,14 +3,13 @@ import * as React from "react";
 import * as CompileConfig from "../../../config.json";
 import { Category } from "../../types";
 import CategorySkipOptionsComponent from "./CategorySkipOptionsComponent";
-import Config from "../../config";
 
 export interface CategoryChooserProps { 
 
 }
 
 export interface CategoryChooserState {
-    selectedChannel: string;
+
 }
 
 class CategoryChooserComponent extends React.Component<CategoryChooserProps, CategoryChooserState> {
@@ -18,30 +17,20 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
     constructor(props: CategoryChooserProps) {
         super(props);
 
-        // Set the selected channel from the part of the document hash after the slash
-        const hashSlashIndex = document.location.hash.indexOf("/");
-        let selectedChannel = hashSlashIndex > -1 ? document.location.hash.slice(hashSlashIndex + 1) : null;
-
-        const channelSpecificSettings = Config.config.channelSpecificSettings;
-        if (channelSpecificSettings[selectedChannel] == undefined)
-            selectedChannel = null;
-
         // Setup state
         this.state = {
-            selectedChannel: selectedChannel
+            
         }
     }
 
     render(): React.ReactElement {
         return (
-            <>
-                {this.getChannelSettings()}
-                <table id="categoryChooserTable"
-                       className="categoryChooserTable">
-                    <tbody>
+            <table id="categoryChooserTable"
+                className="categoryChooserTable"> 
+                <tbody>
                     {/* Headers */}
                     <tr id={"CategoryOptionsRow"}
-                        className="categoryTableElement categoryTableHeader">
+                            className="categoryTableElement categoryTableHeader">
                         <th id={"CategoryOptionName"}>
                             {chrome.i18n.getMessage("category")}
                         </th>
@@ -51,73 +40,20 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
                             {chrome.i18n.getMessage("skipOption")}
                         </th>
 
-                        { // Colour options are only available when configuring global skip settings
-                            this.state.selectedChannel == null &&
-                            <>
-                                <th id={"CategoryColorOption"}
-                                    className="colorOption">
-                                    {chrome.i18n.getMessage("seekBarColor")}
-                                </th>
+                        <th id={"CategoryColorOption"}
+                            className="colorOption">
+                            {chrome.i18n.getMessage("seekBarColor")}
+                        </th>
 
-                                <th id={"CategoryPreviewColorOption"}
-                                    className="previewColorOption">
-                                    {chrome.i18n.getMessage("previewColor")}
-                                </th>
-                            </>
-                        }
+                        <th id={"CategoryPreviewColorOption"}
+                            className="previewColorOption">
+                            {chrome.i18n.getMessage("previewColor")}
+                        </th>
                     </tr>
 
                     {this.getCategorySkipOptions()}
-                    </tbody>
-                </table>
-            </>
-        );
-    }
-
-    // Renders the channel chooser and associated buttons
-    getChannelSettings(): JSX.Element {
-        const channelSpecificSettings = Config.config.channelSpecificSettings;
-        const channelOptions = [];
-        for (const channelID in channelSpecificSettings) {
-            channelOptions.push({
-                name: channelSpecificSettings[channelID].name,
-                element: <option value={channelID}>{
-                    channelSpecificSettings[channelID].name ? channelSpecificSettings[channelID].name : channelID
-                }</option>
-            });
-        }
-        channelOptions.sort((a, b) => {
-            return ('' + a.name).localeCompare(b.name);
-        });
-
-        return (
-            <>
-                <select id="channelChooser"
-                        className="optionsSelector inline"
-                        style={{verticalAlign: "middle"}}
-                        defaultValue={this.state.selectedChannel == null ? "global" : this.state.selectedChannel}
-                        onChange={this.channelSelected.bind(this)}>
-                    <option value="global">- Global Settings -</option>
-                    {channelOptions.map((channelOption) => { return channelOption.element; })}
-                </select>
-                {
-                    this.state.selectedChannel != null &&
-                    <>
-                        <div id="removeChannelSelections"
-                            className="option-button inline"
-                            style={{marginLeft: "5px", padding: "5px", verticalAlign: "middle"}}
-                            onClick={this.removeSelectedChannel.bind(this)}>
-                            {chrome.i18n.getMessage("removeChannelSettingsButton")}
-                        </div>
-                        {
-                            !Config.config.forceChannelCheck &&
-                            <span className="inline"
-                                  style={{marginLeft: "5px"}}>
-                                {chrome.i18n.getMessage("forceChannelCheckRequired")}</span>
-                        }
-                    </>
-                }
-            </>
+                </tbody> 
+            </table>
         );
     }
 
@@ -127,32 +63,12 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
         for (const category of CompileConfig.categoryList) {
             elements.push(
                 <CategorySkipOptionsComponent category={category as Category}
-                    selectedChannel={this.state.selectedChannel}
                     key={category}>
                 </CategorySkipOptionsComponent>
             );
         }
 
         return elements;
-    }
-
-    // Called when a channel is selected in the channel chooser
-    channelSelected(event: React.ChangeEvent<HTMLSelectElement>): void {
-        if (event.target.value == "global") {
-            document.location.hash = "behavior";
-            this.setState({selectedChannel: null});
-        } else {
-            document.location.hash = "behavior/" + event.target.value;
-            this.setState({selectedChannel: event.target.value});
-        }
-    }
-
-    // Removes *all* the selected channel's settings from `channelSpecificSettings`
-    removeSelectedChannel(): void {
-        delete Config.config.channelSpecificSettings[this.state.selectedChannel];
-        this.setState({selectedChannel: null});
-
-        Config.config.channelSpecificSettings = Config.config.channelSpecificSettings;
     }
 }
 

--- a/src/components/options/CategorySkipOptionsComponent.tsx
+++ b/src/components/options/CategorySkipOptionsComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import Config from "../../config"
 import * as CompileConfig from "../../../config.json";
-import { Category, CategorySelection, CategorySkipOption } from "../../types";
+import { Category, CategorySkipOption } from "../../types";
 
 import { getCategorySuffix } from "../../utils/categoryUtils";
 import ToggleOptionComponent from "./ToggleOptionComponent";
@@ -143,7 +143,7 @@ class CategorySkipOptionsComponent extends React.Component<CategorySkipOptionsPr
             if (categorySelections[i].name === this.props.category) {
                 categorySelections.splice(i, 1);
 
-                this.forceSaveCategorySelections(categorySelections);
+                Config.forceSyncUpdate("channelSpecificSettings");
 
                 break;
             }
@@ -154,14 +154,15 @@ class CategorySkipOptionsComponent extends React.Component<CategorySkipOptionsPr
 
         switch (event.target.value) {
             case "inherit":
+                return;
             case "disable":
                 Config.config.categorySelections = Config.config.categorySelections.filter(
                     categorySelection => categorySelection.name !== this.props.category);
+                if (this.props.selectedChannel != null) {
+                    option = CategorySkipOption.Disabled;
+                    break;
+                }
                 return;
-            case "disable":
-                option = CategorySkipOption.Disabled;
-
-                break;
             case "showOverlay":
                 option = CategorySkipOption.ShowOverlay;
 
@@ -182,17 +183,18 @@ class CategorySkipOptionsComponent extends React.Component<CategorySkipOptionsPr
                 break;
         }
 
-        const existingSelection = Config.config.categorySelections.find(selection => selection.name === this.props.category);
+        const existingSelection = categorySelections.find(selection => selection.name === this.props.category);
         if (existingSelection) {
             existingSelection.option = option;
         } else {
-            Config.config.categorySelections.push({
+            categorySelections.push({
                 name: this.props.category,
                 option: option
             });
         }
 
         Config.forceSyncUpdate("categorySelections");
+        Config.forceSyncUpdate("channelSpecificSettings");
     }
 
     getCategorySkipOptions(): JSX.Element[] {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1857,6 +1857,7 @@ function createButton(baseID: string, title: string, callback: () => void, image
     newButton.classList.add("playerButton");
     newButton.classList.add("ytp-button");
     if (isOnYTTV()) {
+        // Some style needs to be set here, but the numbers don't matter 
         newButton.setAttribute("style", "width: 40px; height: 40px");
     }
     newButton.setAttribute("title", chrome.i18n.getMessage(title));

--- a/src/content.ts
+++ b/src/content.ts
@@ -1443,7 +1443,7 @@ async function channelIDChange(channelIDInfo: ChannelIDInfo) {
     if (channelSpecificSettings != undefined &&
         channelIDInfo.status === ChannelIDStatus.Found){
         if (Config.config.forceChannelCheck && channelSpecificSettings[channelIDInfo.id]?.toggle) {
-            sponsorsLookup(false, true);
+            sponsorsLookup(true, true);
         }
         if(channelSpecificSettings[channelIDInfo.id]?.whitelisted) {
             channelWhitelisted = true;

--- a/src/content.ts
+++ b/src/content.ts
@@ -436,7 +436,7 @@ function resetValues() {
     hideDeArrowPromotion();
 }
 
-function videoIDChange(): void {
+async function videoIDChange(): Promise<void> {
     //setup the preview bar
     if (previewBar === null) {
         if (isOnMobileYouTube()) {
@@ -467,10 +467,10 @@ function videoIDChange(): void {
     });
 
     // To attempt to ensure the channel ID has been fetched so that channel-specific categories can be requested
-    if (Config.config.forceChannelCheck)
-        await whitelistCheckResult;
-
-    sponsorsLookup(id);
+    if (Config.config.forceChannelCheck){
+        await channelIDChange(getChannelIDInfo());
+    }
+    sponsorsLookup();
 
     // Make sure all player buttons are properly added
     updateVisibilityOfPlayerControlsButton();
@@ -744,6 +744,7 @@ async function startSponsorSchedule(includeIntersectingSegments = false, current
                 forcedIncludeIntersectingSegments = true;
                 forcedIncludeNonIntersectingSegments = false;
             }
+        }
         }
 
         startSponsorSchedule(forcedIncludeIntersectingSegments, forcedSkipTime, forcedIncludeNonIntersectingSegments);
@@ -1339,7 +1340,7 @@ function startSkipScheduleCheckingForStartSponsors() {
                 && time.actionType === ActionType.Poi && time.hidden === SponsorHideType.Visible)
             .sort((a, b) => b.segment[0] - a.segment[0]);
         for (const time of poiSegments) {
-            const skipOption = utils.getCategorySelection(time.category, channelIDInfo.id)?.option;
+            const skipOption = utils.getCategorySelection(time.category, getChannelIDInfo().id)?.option;
             if (skipOption !== CategorySkipOption.ShowOverlay) {
                 skipToTime({
                     v: getVideo(),
@@ -1432,7 +1433,7 @@ async function channelIDChange(channelIDInfo: ChannelIDInfo) {
     const channelSpecificSettings = Config.config.channelSpecificSettings;
 
     //see if this is a whitelisted channel
-    if (channelWhitelisted = channelSpecificSettings != undefined &&
+    if (channelSpecificSettings != undefined &&
         channelIDInfo.status === ChannelIDStatus.Found &&
         !!channelSpecificSettings[channelIDInfo.id]?.whitelisted) {
         channelWhitelisted = true;
@@ -1890,7 +1891,7 @@ function shouldAutoSkip(segment: SponsorTime): boolean {
 function shouldSkip(segment: SponsorTime): boolean {
     const skipOption = utils.getCategorySelection(segment.category, getChannelIDInfo().id)?.option;
     return segment.actionType !== ActionType.Full &&
-            && segment.source !== SponsorSourceType.YouTube
+        segment.source !== SponsorSourceType.YouTube &&
         (skipOption === CategorySkipOption.ManualSkip || skipOption === CategorySkipOption.AutoSkip
             || (Config.config.autoSkipOnMusicVideos && sponsorTimes?.some((s) => s.category === "music_offtopic")
                 && segment.actionType === ActionType.Skip));

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -14,7 +14,6 @@ interface DefaultMessage {
         | "sponsorStart"
         | "getVideoID"
         | "getChannelInfo"
-        | "isChannelWhitelisted"
         | "submitTimes"
         | "refreshSegments"
         | "closePopup"
@@ -93,16 +92,11 @@ export interface SponsorStartResponse {
     creatingSegment: boolean;
 }
 
-export interface IsChannelWhitelistedResponse {
-    value: boolean;
-}
-
 export type MessageResponse =
     IsInfoFoundMessageResponse
     | GetVideoIdResponse
     | GetChannelIDResponse
     | SponsorStartResponse
-    | IsChannelWhitelistedResponse
     | Record<string, never> // empty object response {}
     | VoteResponse
     | ImportSegmentsResponse
@@ -140,7 +134,6 @@ export type InfoUpdatedMessage = IsInfoFoundMessageResponse & {
 export interface VideoChangedPopupMessage {
     message: "videoChanged";
     videoID: string;
-    whitelisted: boolean;
 }
 
 export type PopupMessage = TimeUpdateMessage | InfoUpdatedMessage | VideoChangedPopupMessage;

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -100,7 +100,7 @@ export interface IsChannelWhitelistedResponse {
 export type MessageResponse =
     IsInfoFoundMessageResponse
     | GetVideoIdResponse
-    | GetChannelInfoResponse
+    | GetChannelIDResponse
     | SponsorStartResponse
     | IsChannelWhitelistedResponse
     | Record<string, never> // empty object response {}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -899,7 +899,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
         }
     }
 
-    function whitelistChannelClick(event) {
+    async function whitelistChannelClick(event) {
         //get the channel url
         const response = await sendTabMessageAsync({ message: 'getChannelInfo' }) as GetChannelIDResponse;
         if (!response.channelID) {
@@ -956,6 +956,7 @@ async function runThePopup(messageListener?: MessageListener): Promise<void> {
             channelSpecificSettings[channelID].whitelisted = true;
         } else {
             channelSpecificSettings[channelID] = {
+                name: channelID,
                 whitelisted: true,
                 categorySelections: []
             };

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,10 +206,9 @@ export interface ChannelIDInfo {
 }
 
 export interface ChannelSpecificSettings {
-    name: string;
     whitelisted: boolean;
     toggle: boolean;
-    categorySelections: CategorySelection[]
+    categorySelections: CategorySelection[];
 }
 
 export interface SkipToTimeParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,8 +206,9 @@ export interface ChannelIDInfo {
 }
 
 export interface ChannelSpecificSettings {
-    name: string,
-    whitelisted: boolean,
+    name: string;
+    whitelisted: boolean;
+    toggle: boolean;
     categorySelections: CategorySelection[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,7 +206,6 @@ export interface ChannelIDInfo {
 }
 
 export interface ChannelSpecificSettings {
-    whitelisted: boolean;
     toggle: boolean;
     categorySelections: CategorySelection[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,7 +229,7 @@ export default class Utils {
     }
 
     getCategorySelection(category: string, channelID: string = null): CategorySelection {
-        if (channelID != null && Config.config.channelSpecificSettings[channelID]) {
+        if (channelID != null && Config.config.channelSpecificSettings[channelID]?.toggle) {
             for (const channelSelection of Config.config.channelSpecificSettings[channelID].categorySelections) {
                 if (channelSelection.name === category)
                     return channelSelection;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,23 +211,6 @@ export default class Utils {
         return sponsorTimes[this.getSponsorIndexFromUUID(sponsorTimes, UUID)];
     }
 
-    createCategorySelectionList(channelID: string = null): CategorySelection[] {
-        const resultList = new Map<string, CategorySelection>();
-
-        // Channel-specific selections take priority
-        if (channelID != null && Config.config.channelSpecificSettings[channelID])
-            for (const channelSelection of Config.config.channelSpecificSettings[channelID].categorySelections)
-                if (channelSelection.option != CategorySkipOption.Disabled)
-                    resultList.set(channelSelection.name, channelSelection);
-
-        // Then global settings fill in everything else
-        for (const selection of Config.config.categorySelections)
-            if (!resultList.get(selection.name) && selection.option != CategorySkipOption.Disabled)
-                resultList.set(selection.name, selection);
-
-        return [...resultList.values()];
-    }
-
     getCategorySelection(category: string, channelID: string = null): CategorySelection {
         if (channelID != null && Config.config.channelSpecificSettings[channelID]?.toggle) {
             for (const channelSelection of Config.config.channelSpecificSettings[channelID].categorySelections) {
@@ -236,7 +219,7 @@ export default class Utils {
             }
         }
         for (const selection of Config.config.categorySelections) {
-            if (selection.name === category){
+            if (selection.name === category) {
                 return selection;
             }
         }


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

Combines implementation of channel specific category selections from #1372 (for the popup UI) and #1261. Thank you to both @zedseven and @scaccoman, as I likely wouldn't have even attempted this were it not for their previous work.

Additional minor changes also include:
 - Slightly modifying the popup UI in order to account for other languages having longer skip option and category names
 - Changing the `inherit` option's name to `global` in order to clearly convey that it uses the option selected in the global config
 - Adding a clarification of what the currently selected `global` option is, in parentheses
 
![currently selected global option in parentheses](https://github.com/user-attachments/assets/143d0af2-1bdf-413e-ba23-fb7d5332a582)

 - Adding a delete channel settings button in the popup (otherwise, the settings are only deleted if their category selections are empty)
 
![delete channel settings button](https://github.com/user-attachments/assets/42146d60-ab39-45d6-9d40-f8f81b2713ea)

 
Finally, removes the whitelist system entirely. Instead, existing whitelists are converted to have all non-disabled categories at `Show overlay` in the channel settings.

Also see https://github.com/ajayyy/ExtensionTranslations/pull/81