### PR TITLE
Hide skip sponsor button while YouTube's own ads are playing

### DIFF
--- a/public/content.css
+++ b/public/content.css
@@ -947,3 +947,8 @@ input::-webkit-inner-spin-button {
 .sponsorblock-chapter-visible {
 	display: inherit !important;
 }
+
+/* hide sponsorSkip while youtube ad is playing */
+.ad-showing .sponsorSkipNoticeContainer {
+  display: none;
+}


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
What does the change do: SponsorBlock will now be hidden during YouTube's own ads.

The skip sponsor button can appear during YouTube ads. If you accidentally click skip, as sometimes YouTube ads start just before a sponsorBlock, YouTube will notify the user that it thinks that an adblocker is being used.

Example of what happened before the change:
![image](https://github.com/user-attachments/assets/1a5dedfa-2a79-4631-bd4e-c1b1c8ff765a)
