### PR TITLE
Fix segment hiding/unhiding

### DIFF
--- a/src/popup/SegmentListComponent.tsx
+++ b/src/popup/SegmentListComponent.tsx
@@ -149,6 +149,11 @@ function SegmentListItem({ segment, videoID, currentTime, isVip, loopedChapter, 
     const [hidden, setHidden] = React.useState(segment.hidden ?? SponsorHideType.Visible); // undefined ?? undefined lol
     const [isLooped, setIsLooped] = React.useState(loopedChapter === segment.UUID);
 
+    // Update internal state if the hidden property of the segment changes
+    React.useEffect(() => {
+        setHidden(segment.hidden ?? SponsorHideType.Visible);
+    }, [segment.hidden])
+
     let extraInfo: string;
     switch (hidden) {
         case SponsorHideType.Visible:


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
[issue reported on discord](https://discord.com/channels/603643120093233162/603643256714297374/1418563576226119722)
The issue itself was triggered by [this line in PR #2334](https://github.com/ajayyy/SponsorBlock/pull/2334/files#diff-0885c230b87020856a81ffc8cf0303ab633e364e7f79071f60e6f0a3d8c26df7R91), as it shallow-cloned the segment object. The list item component relied on object mutation propagating up to the root popup component when unhiding, which was stopped in the list display due to this clone, and even worse - the changes would be discarded on the next rerender of the list.

This PR fixes this issue by making the list item trust it's own state variable for hidden status, which already existed but wasn't actually used.
This is safe, because:
- the state variable is initialized to the segment's value on first render, and will be updated when the segment's hidden property updates
- all uses of the SegmentListItem component set the segment's uuid as the key, ensuring that it will not get reused when segments update
- the root popup component will never derender the SegmentListComponent (no conditional rendering)
- components that use the SegmentListItem component will not derender it unless the segment lists change

this PR also uses the `React.useMemo` hook to cache segment nesting results