### PR TITLE
fix: Add missing clipboard write permission

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -17,8 +17,7 @@
     "permissions": [
         "storage",
         "scripting",
-        "unlimitedStorage",
-        "clipboardWrite"
+        "unlimitedStorage"
     ],
     "options_ui": {
         "page": "options/options.html",


### PR DESCRIPTION
- [X] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

This fixes: https://github.com/ajayyy/SponsorBlock/issues/2362

Added 'clipboardWrite' to extension permissions in manifest.json and set 'allow' attribute to 'clipboard-write' on the info menu iframe to enable clipboard operations.


## Testing Results
Before:
<img width="2912" height="1578" alt="image" src="https://github.com/user-attachments/assets/7d5cb3f5-66e6-4450-9a63-8a1bff1fd679" />

After:
Copy button working as expected. No exception in console.
<img width="2895" height="1591" alt="image" src="https://github.com/user-attachments/assets/c4e4f1bc-1a53-40c7-84e0-709d81d1dd63" />

