### PR TITLE
Add use_dynamic_url for web_accessible_resources

### DIFF
--- a/manifest/chrome-manifest-extra.json
+++ b/manifest/chrome-manifest-extra.json
@@ -66,7 +66,8 @@
       "libs/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwmBduz8A.woff2",
       "libs/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwlBduz8A.woff2"
     ],
-    "matches": ["<all_urls>"]
+    "matches": ["<all_urls>"],
+    "use_dynamic_url": true
   }],
   "content_scripts": [
     {


### PR DESCRIPTION
This PR adds `use_dynamic_url` for `web_accessible_resourcese` to prevent detection in Chromium browsers.

See: https://browserleaks.com/chrome#web-accessible-resources-detection

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
