### PR TITLE
Fix outro end time not auto-filling when category is selected via keyboard

### DIFF
--- a/src/components/SponsorTimeEditComponent.tsx
+++ b/src/components/SponsorTimeEditComponent.tsx
@@ -678,7 +678,7 @@ class SponsorTimeEditComponent extends React.Component<SponsorTimeEditProps, Spo
                 // Only start time is valid, still an incomplete segment
                 sponsorTimesSubmitting[this.props.index].segment[0] = startTime;
             }
-        } else if (this.state.sponsorTimeEdits[1] === null && category === "outro" && !sponsorTimesSubmitting[this.props.index].segment[1]) {
+        } else if (category === "outro" && !sponsorTimesSubmitting[this.props.index].segment[1]) {
             sponsorTimesSubmitting[this.props.index].segment[1] = getVideoDuration();
             this.props.contentContainer().updateEditButtonsOnPlayer();
         }


### PR DESCRIPTION
## Problem

When the **Endcards/Credits** (`outro`) category is chosen for a segment, SponsorBlock auto-fills the segment's end time to the end of the video. This works when the category is selected with the mouse, but selecting it with the keyboard fills the end time with `0:00` instead.

## Steps to reproduce

1. On a YouTube video, start a new segment (set a start time) and open the segment edit menu.
2. Focus the category dropdown and press `e` twice to reach **Endcards/Credits** (browser type-ahead).
3. **Expected:** end time becomes the video duration. **Actual:** end time is `0:00`.

## Root cause

The category `<select>` has two options whose labels start with "E":

| Order | Label | Category | Action support |
|-------|-------|----------|----------------|
| earlier | Exclusive Access | `exclusive_access` | `full` only |
| later | Endcards/Credits | `outro` | `skip`, `mute` |

Keyboard type-ahead lands on **Exclusive Access** first. Because it is a full-video category, `saveEditTimes()` zeroes the segment to `[0, 0]` and writes `"0:00.000"` into `sponsorTimeEdits`. The second `e` then reaches **Endcards/Credits**, but the outro auto-fill was gated behind `this.state.sponsorTimeEdits[1] === null` — no longer true after the detour — so it was skipped and the end time stayed `0`. The mouse path never passes through Exclusive Access, which is why only the keyboard path was affected.

## Fix

Drop the stale `sponsorTimeEdits[1] === null` guard. The condition already checks `!segment[1]`, which correctly detects an unset end time and, unlike the edits state, is not polluted by passing through the full-video category.

```diff
-        } else if (this.state.sponsorTimeEdits[1] === null && category === "outro" && !sponsorTimesSubmitting[this.props.index].segment[1]) {
+        } else if (category === "outro" && !sponsorTimesSubmitting[this.props.index].segment[1]) {
```

## Testing

- `npm run build:dev:chrome` builds cleanly; type-check passes.
- Loaded via `web-ext run -t chromium` and verified on a YouTube video: selecting Endcards/Credits via keyboard (`e`, `e`) now fills the end time with the video duration, matching the mouse behavior. Mouse selection and segments with an explicit end time are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A video to demonstrate the fix

https://github.com/user-attachments/assets/b0ec0cb8-3cd8-4839-9f0d-75a8938e1161