### PR TITLE
Fix hidden state changes from minimum duration

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -371,6 +371,7 @@ function contentConfigUpdateListener(changes: StorageChangesObject) {
                 updateVisibilityOfPlayerControlsButton()
                 break;
             case "categorySelections":
+            case "minDuration":
                 channelIDChange();
                 break;
             case "barTypes":

--- a/src/utils/skipProfiles.ts
+++ b/src/utils/skipProfiles.ts
@@ -85,14 +85,13 @@ function getSkipProfileValue<T>(key: keyof CustomConfiguration): T {
 export function hideTooShortSegments(sponsorTimes: SponsorTime[]) {
     const minDuration = getSkipProfileNum("minDuration");
 
-    if (minDuration !== 0) {
-        for (const segment of sponsorTimes) {
-            const duration = segment.segment[1] - segment.segment[0];
-            if (duration > 0 && duration < minDuration && (segment.hidden === SponsorHideType.Visible || SponsorHideType.MinimumDuration)) {
-                segment.hidden = SponsorHideType.MinimumDuration;
-            } else if (segment.hidden === SponsorHideType.MinimumDuration) {
-                segment.hidden = SponsorHideType.Visible;
-            }
+    for (const segment of sponsorTimes) {
+        const duration = segment.segment[1] - segment.segment[0];
+        const tooShort = minDuration > 0 && duration > 0 && duration < minDuration;
+        if (tooShort && (segment.hidden === SponsorHideType.Visible || segment.hidden === SponsorHideType.MinimumDuration)) {
+            segment.hidden = SponsorHideType.MinimumDuration;
+        } else if (!tooShort && segment.hidden === SponsorHideType.MinimumDuration) {
+            segment.hidden = SponsorHideType.Visible;
         }
     }
 }

--- a/test/skipProfiles.test.ts
+++ b/test/skipProfiles.test.ts
@@ -1,0 +1,65 @@
+jest.mock("../src/config", () => ({
+    __esModule: true,
+    default: {
+        config: {
+            minDuration: 0
+        },
+        local: {
+            skipProfileTemp: null,
+            channelSkipProfileIDs: {},
+            skipProfiles: {}
+        }
+    }
+}));
+
+jest.mock("../maze-utils/src/video", () => ({
+    getChannelIDInfo: jest.fn(),
+    getVideoID: jest.fn()
+}));
+
+import Config from "../src/config";
+import { hideTooShortSegments } from "../src/utils/skipProfiles";
+import { ActionType, Category, SegmentUUID, SponsorHideType, SponsorSourceType, SponsorTime } from "../src/types";
+
+function createSegment(hidden: SponsorHideType = SponsorHideType.Visible): SponsorTime {
+    return {
+        segment: [10, 15],
+        UUID: "test" as SegmentUUID,
+        category: "sponsor" as Category,
+        actionType: ActionType.Skip,
+        source: SponsorSourceType.Server,
+        hidden
+    };
+}
+
+describe("hideTooShortSegments", () => {
+    beforeEach(() => {
+        Config.config.minDuration = 0;
+    });
+
+    it("preserves downvoted and manually hidden short segments", () => {
+        const downvoted = createSegment(SponsorHideType.Downvoted);
+        const hidden = createSegment(SponsorHideType.Hidden);
+
+        Config.config.minDuration = 10;
+        hideTooShortSegments([downvoted, hidden]);
+
+        Config.config.minDuration = 4;
+        hideTooShortSegments([downvoted, hidden]);
+
+        expect(downvoted.hidden).toBe(SponsorHideType.Downvoted);
+        expect(hidden.hidden).toBe(SponsorHideType.Hidden);
+    });
+
+    it("restores only minimum-duration segments when the threshold is removed", () => {
+        const segment = createSegment();
+
+        Config.config.minDuration = 10;
+        hideTooShortSegments([segment]);
+        expect(segment.hidden).toBe(SponsorHideType.MinimumDuration);
+
+        Config.config.minDuration = 0;
+        hideTooShortSegments([segment]);
+        expect(segment.hidden).toBe(SponsorHideType.Visible);
+    });
+});


### PR DESCRIPTION
## Summary

- preserve downvoted and manually hidden segments when applying the minimum-duration filter
- restore only segments hidden by that filter when the threshold changes or is removed
- apply `minDuration` updates to the current video immediately

## Root cause

The minimum-duration predicate treated the `MinimumDuration` enum member as an unconditional truthy value, so it relabeled every short segment. The previous zero-threshold branch also left filter-hidden segments unchanged.

## Validation

- `npm run test-without-building -- --runInBand`
- `npm run lint`
- `npm run build:chrome`
- `npm audit --omit=dev --json` (0 production vulnerabilities)
