### PR TITLE
Add skip once feature

### DIFF
--- a/src/components/options/CategorySkipOptionsComponent.tsx
+++ b/src/components/options/CategorySkipOptionsComponent.tsx
@@ -39,6 +39,8 @@ export function CategorySkipOptionsComponent(props: CategorySkipOptionsProps): R
                 return "showOverlay";
             case CategorySkipOption.ManualSkip:
                 return "manualSkip";
+            case CategorySkipOption.SkipOnce:
+                return "skipOnce";
             case CategorySkipOption.AutoSkip:
                 return "autoSkip";
             case CategorySkipOption.FallbackToDefault:
@@ -155,6 +157,16 @@ function skipOptionSelected(event: React.ChangeEvent<HTMLSelectElement>,
         case "manualSkip":
             option = CategorySkipOption.ManualSkip;
             break;
+        case "skipOnce":
+            option = CategorySkipOption.SkipOnce;
+
+            if (category === "filler" && !Config.config.isVip) {
+                if (!confirm(chrome.i18n.getMessage("FillerWarning"))) {
+                    event.target.value = "disable";
+                }
+            }
+
+            break;
         case "autoSkip":
             option = CategorySkipOption.AutoSkip;
 
@@ -173,7 +185,7 @@ function skipOptionSelected(event: React.ChangeEvent<HTMLSelectElement>,
 function getCategorySkipOptions(category: Category, isDefaultConfig: boolean): JSX.Element[] {
     const elements: JSX.Element[] = [];
 
-    let optionNames = ["disable", "showOverlay", "manualSkip", "autoSkip"];
+    let optionNames = ["disable", "showOverlay", "manualSkip", "skipOnce", "autoSkip"];
     if (category === "chapter") optionNames = ["disable", "showOverlay"]
     else if (category === "exclusive_access") optionNames = ["disable", "showOverlay"];
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -51,7 +51,8 @@ import { isMobileControlsOpen } from "./utils/mobileUtils";
 import { defaultPreviewTime } from "./utils/constants";
 import { onVideoPage } from "../maze-utils/src/pageInfo";
 import { getSegmentsForVideo } from "./utils/segmentData";
-import { getCategoryDefaultSelection, getCategorySelection } from "./utils/skipRule";
+import { getCategoryDefaultSelection, getCategorySelection, getRawCategorySelection } from "./utils/skipRule";
+import { hasAutoSkippedOnce, markAutoSkippedOnce, resetAutoSkippedOnce } from "./utils/skipOnce";
 import { getSkipProfileBool, getSkipProfileIDForTab, hideTooShortSegments, setCurrentTabSkipProfile } from "./utils/skipProfiles";
 import { FetchResponse, logRequest } from "../maze-utils/src/background-request-proxy";
 
@@ -220,7 +221,7 @@ function messageListener(request: Message, sender: unknown, sendResponse: (respo
             sendResponse({
                 found: sponsorDataFound,
                 status: lastResponseStatus,
-                sponsorTimes: sponsorTimes.filter((segment) => getCategorySelection(segment).option !== CategorySkipOption.Disabled),
+                sponsorTimes: getSegmentsForPopup(),
                 time: getCurrentTime() ?? 0,
                 onMobileYouTube: isOnMobileYouTube(),
                 videoID: getVideoID(),
@@ -371,6 +372,7 @@ function contentConfigUpdateListener(changes: StorageChangesObject) {
                 updateVisibilityOfPlayerControlsButton()
                 break;
             case "categorySelections":
+                resetAutoSkippedOnce();
                 channelIDChange();
                 break;
             case "barTypes":
@@ -390,6 +392,7 @@ function contentLocalConfigUpdateListener(changes: StorageChangesObject) {
             case "skipProfiles":
             case "skipProfileTemp":
             case "skipRules":
+                resetAutoSkippedOnce();
                 channelIDChange();
                 break;
         }
@@ -416,6 +419,7 @@ function resetValues() {
     existingChaptersImported = false;
     sponsorSkipped = [];
     loopedChapter = null;
+    resetAutoSkippedOnce();
     lastResponseStatus = 0;
     shownSegmentFailedToFetchWarning = false;
 
@@ -734,6 +738,7 @@ async function startSponsorSchedule(includeIntersectingSegments = false, current
                     && segment.actionType !== ActionType.Chapter
                     && segment.hidden === SponsorHideType.Visible))) {
             if (forceVideoTime >= skipTime[0] - skipBuffer && (forceVideoTime < skipTime[1] || skipTime[1] < skipTime[0])) {
+                const skippedAutomatically = getCategorySelection(currentSkip)?.option === CategorySkipOption.AutoSkip;
                 skipToTime({
                     v: getVideo(),
                     skipTime,
@@ -754,7 +759,7 @@ async function startSponsorSchedule(includeIntersectingSegments = false, current
                     }
                 }
 
-                if (getCategorySelection(currentSkip)?.option === CategorySkipOption.ManualSkip
+                if (!skippedAutomatically
                         || currentSkip.actionType === ActionType.Mute) {
                     forcedSkipTime = skipTime[0] + 0.001;
                 } else {
@@ -1274,13 +1279,20 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreCache = false) {
     }
 }
 
+function getSegmentsForPopup(): SponsorTime[] {
+    return sponsorTimes?.filter((segment) => getCategorySelection(segment).option !== CategorySkipOption.Disabled)
+        .map((segment) => getRawCategorySelection(segment).option === CategorySkipOption.SkipOnce
+            ? { ...segment, autoSkippedOnce: hasAutoSkippedOnce(segment.UUID) }
+            : segment) ?? [];
+}
+
 function notifyPopupOfSegments(): void {
     // notify popup of segment changes
     chrome.runtime.sendMessage({
         message: "infoUpdated",
         found: sponsorDataFound,
         status: lastResponseStatus,
-        sponsorTimes: sponsorTimes.filter((segment) => getCategorySelection(segment).option !== CategorySkipOption.Disabled),
+        sponsorTimes: getSegmentsForPopup(),
         time: getCurrentTime() ?? 0,
         onMobileYouTube: isOnMobileYouTube(),
         videoID: getVideoID(),
@@ -1766,6 +1778,15 @@ function skipToTime({v, skipTime, skippingSegments, openNotice, forceAutoSkip, u
 
     if ((autoSkip || isSubmittingSegment)
             && getCurrentTime() !== skipTime[1]) {
+        let anySkippedOnce = false;
+        for (const segment of skippingSegments) {
+            if (getRawCategorySelection(segment)?.option === CategorySkipOption.SkipOnce && segment.UUID) {
+                markAutoSkippedOnce(segment.UUID);
+                anySkippedOnce = true;
+            }
+        }
+        if (anySkippedOnce) notifyPopupOfSegments();
+
         switch(skippingSegments[0].actionType) {
             case ActionType.Poi:
             case ActionType.Chapter:

--- a/src/popup/SegmentListComponent.tsx
+++ b/src/popup/SegmentListComponent.tsx
@@ -199,6 +199,10 @@ function SegmentListItem({ segment, videoID, currentTime, isVip, loopedChapter, 
             extraInfo = "";
     }
 
+    if (segment.autoSkippedOnce !== undefined) {
+        extraInfo += " (" + chrome.i18n.getMessage(segment.autoSkippedOnce ? "alreadySkippedOnce" : "willSkipOnce") + ")";
+    }
+
     return (
         <div className={"segmentWrapper " + (!tabFilter(segment) ? "hidden" : "")}>
             <details data-uuid={segment.UUID}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,8 @@ export enum CategorySkipOption {
     Disabled = -1,
     ShowOverlay,
     ManualSkip,
-    AutoSkip
+    AutoSkip,
+    SkipOnce
 }
 
 export interface CategorySelection {
@@ -90,6 +91,8 @@ export interface SponsorTime extends SegmentContainer {
     hidden?: SponsorHideType;
     source: SponsorSourceType;
     videoDuration?: number;
+
+    autoSkippedOnce?: boolean;
 }
 
 export interface ScheduledTime extends SponsorTime {

--- a/src/utils/skipOnce.ts
+++ b/src/utils/skipOnce.ts
@@ -1,0 +1,15 @@
+import { SegmentUUID } from "../types";
+
+const autoSkippedOnce = new Set<SegmentUUID>();
+
+export function hasAutoSkippedOnce(UUID: SegmentUUID): boolean {
+    return autoSkippedOnce.has(UUID);
+}
+
+export function markAutoSkippedOnce(UUID: SegmentUUID): void {
+    autoSkippedOnce.add(UUID);
+}
+
+export function resetAutoSkippedOnce(): void {
+    autoSkippedOnce.clear();
+}

--- a/src/utils/skipRule.ts
+++ b/src/utils/skipRule.ts
@@ -3,6 +3,7 @@ import { getChannelIDInfo, getVideoDuration } from "../../maze-utils/src/video";
 import Config from "../config";
 import {ActionType, ActionTypes, CategorySelection, CategorySkipOption, SponsorSourceType, SponsorTime} from "../types";
 import { getSkipProfile, getSkipProfileBool } from "./skipProfiles";
+import { hasAutoSkippedOnce } from "./skipOnce";
 import { VideoLabelsCacheData } from "./videoLabels";
 import * as CompileConfig from "../../config.json";
 import { AdvancedSkipCheck, AdvancedSkipPredicate, AdvancedSkipRule, PredicateOperator, SkipRuleAttribute, SkipRuleOperator } from "./skipRule.type";
@@ -28,6 +29,19 @@ const OPERATOR_EXTRA_CHARACTER = /[<>=!~*&|-]/;
 const ANY_EXTRA_CHARACTER = /[a-zA-Z0-9<>=!~*&|.-]/;
 
 export function getCategorySelection(segment: SponsorTime | VideoLabelsCacheData): CategorySelection {
+    const selection = getRawCategorySelection(segment);
+    if (selection.option === CategorySkipOption.SkipOnce) {
+        const UUID = (segment as SponsorTime).UUID;
+        return {
+            name: selection.name,
+            option: UUID && hasAutoSkippedOnce(UUID) ? CategorySkipOption.ManualSkip : CategorySkipOption.AutoSkip
+        } as CategorySelection;
+    }
+
+    return selection;
+}
+
+export function getRawCategorySelection(segment: SponsorTime | VideoLabelsCacheData): CategorySelection {
     // First check skip rules
     for (const rule of Config.local.skipRules) {
         if (isSkipPredicatePassing(segment, rule.predicate)) {
@@ -174,7 +188,7 @@ export function getCategoryDefaultSelection(category: string): CategorySelection
 
 type TokenType =
     | "if" // Keywords
-    | "disabled" | "show overlay" | "manual skip" | "auto skip" // Skip option
+    | "disabled" | "show overlay" | "manual skip" | "auto skip" | "auto skip once" // Skip option
     | `${SkipRuleAttribute}` // Segment attributes
     | `${SkipRuleOperator}` // Segment attribute operators
     | "and" | "or" | "not" // Expression operators
@@ -383,7 +397,7 @@ class Lexer {
             }
         } else {
             const keyword2 = this.expectKeyword(
-                [ "disabled", "show overlay", "manual skip", "auto skip" ], false);
+                [ "disabled", "show overlay", "manual skip", "auto skip once", "auto skip" ], false);
 
             if (keyword2 !== null) {
                 kind = "word";
@@ -731,7 +745,7 @@ class Parser {
         this.expect(["if"], rule.comments.length !== 0 ? "expected `if` after `comment`" : "expected `if`", true);
         rule.predicate = this.parsePredicate();
 
-        this.expect(["disabled", "show overlay", "manual skip", "auto skip"], "expected skip option after condition", true);
+        this.expect(["disabled", "show overlay", "manual skip", "auto skip", "auto skip once"], "expected skip option after condition", true);
         switch (this.previous.type) {
             case "disabled":
                 rule.skipOption = CategorySkipOption.Disabled;
@@ -744,6 +758,9 @@ class Parser {
                 break;
             case "auto skip":
                 rule.skipOption = CategorySkipOption.AutoSkip;
+                break;
+            case "auto skip once":
+                rule.skipOption = CategorySkipOption.SkipOnce;
                 break;
             default:
             // Ignore, should have already errored
@@ -881,6 +898,9 @@ export function configToText(config: AdvancedSkipRule[]): string {
                 break;
             case CategorySkipOption.AutoSkip:
                 result += "\nAuto Skip";
+                break;
+            case CategorySkipOption.SkipOnce:
+                result += "\nAuto Skip Once";
                 break;
             default:
                 return null; // Invalid skip option

--- a/test/skipOnce.test.ts
+++ b/test/skipOnce.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("../src/config", () => ({
+    __esModule: true,
+    default: {
+        config: {
+            categorySelections: [{ name: "sponsor", option: 3 }]
+        },
+        local: {
+            skipRules: [],
+            skipProfiles: [],
+            channelSkipProfileIDs: {},
+            skipProfileTemp: null
+        }
+    }
+}));
+
+import { CategorySkipOption, SponsorTime, SegmentUUID } from "../src/types";
+import { getCategorySelection, getRawCategorySelection } from "../src/utils/skipRule";
+import { hasAutoSkippedOnce, markAutoSkippedOnce, resetAutoSkippedOnce } from "../src/utils/skipOnce";
+
+const segment = {
+    UUID: "uuid-1" as SegmentUUID,
+    segment: [10, 20],
+    category: "sponsor",
+    actionType: "skip",
+    source: 1
+} as unknown as SponsorTime;
+
+describe("skip once resolution", () => {
+    beforeEach(() => {
+        resetAutoSkippedOnce();
+    });
+
+    it("resolves to auto skip before the segment has been skipped", () => {
+        expect(getCategorySelection(segment).option).toBe(CategorySkipOption.AutoSkip);
+    });
+
+    it("resolves to manual skip after the segment has been skipped once", () => {
+        markAutoSkippedOnce(segment.UUID);
+
+        expect(hasAutoSkippedOnce(segment.UUID)).toBe(true);
+        expect(getCategorySelection(segment).option).toBe(CategorySkipOption.ManualSkip);
+    });
+
+    it("keeps the stored option available for the options page", () => {
+        markAutoSkippedOnce(segment.UUID);
+
+        expect(getRawCategorySelection(segment).option).toBe(CategorySkipOption.SkipOnce);
+    });
+
+    it("only consumes the segment that was skipped", () => {
+        markAutoSkippedOnce(segment.UUID);
+        const otherSegment = { ...segment, UUID: "uuid-2" as SegmentUUID };
+
+        expect(getCategorySelection(otherSegment).option).toBe(CategorySkipOption.AutoSkip);
+    });
+
+    it("goes back to auto skip after a reset", () => {
+        markAutoSkippedOnce(segment.UUID);
+        resetAutoSkippedOnce();
+
+        expect(getCategorySelection(segment).option).toBe(CategorySkipOption.AutoSkip);
+    });
+});

--- a/test/skipRule.test.ts
+++ b/test/skipRule.test.ts
@@ -1,0 +1,28 @@
+import { parseConfig, configToText } from "../src/utils/skipRule";
+import { CategorySkipOption } from "../src/types";
+
+describe("advanced skip rule skip options", () => {
+    it("parses `auto skip once` without it being shadowed by `auto skip`", () => {
+        const { rules, errors } = parseConfig("if category == \"sponsor\"\nauto skip once");
+
+        expect(errors).toEqual([]);
+        expect(rules).toHaveLength(1);
+        expect(rules[0].skipOption).toBe(CategorySkipOption.SkipOnce);
+    });
+
+    it("still parses `auto skip`", () => {
+        const { rules, errors } = parseConfig("if category == \"sponsor\"\nauto skip");
+
+        expect(errors).toEqual([]);
+        expect(rules[0].skipOption).toBe(CategorySkipOption.AutoSkip);
+    });
+
+    it("round trips `auto skip once` through configToText", () => {
+        const { rules } = parseConfig("if category == \"sponsor\"\nauto skip once");
+        const text = configToText(rules);
+        const reparsed = parseConfig(text);
+
+        expect(reparsed.errors).toEqual([]);
+        expect(reparsed.rules[0].skipOption).toBe(CategorySkipOption.SkipOnce);
+    });
+});


### PR DESCRIPTION
Inspiration from mobile sponsorblock where you can skip a segment once but upon going back it won't skip again

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
