### PR TITLE
show hotkeys for upvote/downvote buttons

### DIFF
--- a/src/components/SkipNoticeComponent.tsx
+++ b/src/components/SkipNoticeComponent.tsx
@@ -228,7 +228,7 @@ class SkipNoticeComponent extends React.Component<SkipNoticeProps, SkipNoticeSta
                         <div id={"sponsorTimesDownvoteButtonsContainerUpvote" + this.idSuffix}
                                 className="voteButton"
                                 style={{marginRight: "5px"}}
-                                title={chrome.i18n.getMessage("upvoteButtonInfo")}
+                                title={chrome.i18n.getMessage("upvoteButtonInfo") + " (" + keybindToString(Config.config.upvoteKeybind) + ")"}
                                 onClick={() => this.prepAction(SkipNoticeAction.Upvote)}>
                             <ThumbsUpSvg fill={(this.state.actionState === SkipNoticeAction.Upvote) ? this.selectedColor : this.unselectedColor} />
                         </div>
@@ -237,7 +237,7 @@ class SkipNoticeComponent extends React.Component<SkipNoticeProps, SkipNoticeSta
                         <div id={"sponsorTimesDownvoteButtonsContainerDownvote" + this.idSuffix}
                                 className="voteButton"
                                 style={{marginRight: "5px", marginLeft: "5px"}}
-                                title={chrome.i18n.getMessage("reportButtonInfo")}
+                                title={chrome.i18n.getMessage("reportButtonInfo") + " (" + keybindToString(Config.config.downvoteKeybind) + ")"}
                                 onClick={() => this.prepAction(SkipNoticeAction.Downvote)}>
                             <ThumbsDownSvg fill={downvoteButtonColor(this.segments, this.state.actionState, SkipNoticeAction.Downvote)} />
                         </div>


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

***
Show the shortcut keys for upvote/downvote to match "Unskip(Enter)"

screenshots:
<img width="330" height="116" alt="doww" src="https://github.com/user-attachments/assets/b1f13df2-c9e6-41c7-a1ef-ed96e980acba" />
<img width="337" height="119" alt="upp" src="https://github.com/user-attachments/assets/27cba928-b827-412b-8d5e-25dd8704dc7e" />
