### PR TITLE
add time units for skip notice countdown

### DIFF
--- a/src/components/NoticeComponent.tsx
+++ b/src/components/NoticeComponent.tsx
@@ -67,6 +67,32 @@ export interface NoticeState {
 
 // Limits for dragging notice around
 const bounds = [10, 100, 10, 10];
+const timeUnits = [
+    {
+        // key of the string to use
+        translationKey: "NoticeTimeAfterSkip",
+        // placeholder in the string to replace
+        variable: "{seconds}",
+        // what to divide by to get the next unit
+        nextDiv: 60,
+    },
+    {
+        translationKey: "NoticeTimeAfterSkipMinutes",
+        variable: "{minutes}",
+        nextDiv: 60,
+    },
+    {
+        translationKey: "NoticeTimeAfterSkipHours",
+        variable: "{hours}",
+        nextDiv: 24,
+    },
+    {
+        translationKey: "NoticeTimeAfterSkipDays",
+        variable: "{days}",
+        nextDiv: 10,
+    },
+]
+type TimeUnit = typeof timeUnits extends (infer T)[] ? T : never;
 
 class NoticeComponent extends React.Component<NoticeProps, NoticeState> {
     countdownInterval: NodeJS.Timeout;
@@ -249,12 +275,21 @@ class NoticeComponent extends React.Component<NoticeProps, NoticeState> {
     }
 
     getCountdownElements(): React.ReactElement[] {
+        let number = Math.ceil(this.state.countdownTime);
+        let finalUnit: TimeUnit;
+        for (const unit of timeUnits) {
+            if (unit.nextDiv > number) {
+                finalUnit = unit;
+                break;
+            }
+            number = Math.floor(number / unit.nextDiv);
+        }
         return [(
                     <span 
                         id={"skipNoticeTimerText" + this.idSuffix}
                         key="skipNoticeTimerText"
                         className={this.state.countdownMode !== CountdownMode.Timer ? "sbhidden" : ""} >
-                            {chrome.i18n.getMessage("NoticeTimeAfterSkip").replace("{seconds}", Math.ceil(this.state.countdownTime).toString())}
+                            {finalUnit === undefined ? "∞" : chrome.i18n.getMessage(finalUnit.translationKey).replace(finalUnit.variable, number.toString())}
                     </span>
                 ),(
                     <img 


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/SponsorBlock/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
[as reported on discord](https://discord.com/channels/603643120093233162/603643256714297374/1544871177053409381), the countdown can get a bit long
this pr makes it switch units to s > m > h > d, to get the countdown string to be as short as possible
after reaching 10d it is replaced with ∞